### PR TITLE
Ability to disable the exception being appended to the end of the message

### DIFF
--- a/SumoLogic.Logging.NLog/BufferedSumoLogicTarget.cs
+++ b/SumoLogic.Logging.NLog/BufferedSumoLogicTarget.cs
@@ -77,6 +77,7 @@ namespace SumoLogic.Logging.NLog
             this.MaxQueueSizeBytes = 1000000;
             this.LogLog = log ?? new DummyLog();
             this.HttpMessageHandler = httpMessageHandler;
+            this.AppendException = true;
         }
 
         /// <summary>
@@ -157,6 +158,15 @@ namespace SumoLogic.Logging.NLog
         /// Gets or sets a value indicating whether the console log should be used.
         /// </summary>
         public bool UseConsoleLog
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the exception.ToString() should be automatically appended to the message being sent
+        /// </summary>
+        public bool AppendException
         {
             get;
             set;
@@ -282,7 +292,7 @@ namespace SumoLogic.Logging.NLog
             using (var textWriter = new StringWriter(bodyBuilder, CultureInfo.InvariantCulture))
             {
                 textWriter.Write(Layout.Render(logEvent));
-                if (logEvent.Exception != null)
+                if (logEvent.Exception != null && this.AppendException)
                 {
                     textWriter.Write(logEvent.Exception.ToString());
                 }

--- a/SumoLogic.Logging.NLog/SumoLogicTarget.cs
+++ b/SumoLogic.Logging.NLog/SumoLogicTarget.cs
@@ -59,7 +59,8 @@ namespace SumoLogic.Logging.NLog
             this.SourceName = "Nlog-SumoObject";
             this.ConnectionTimeout = 60000;            
             this.LogLog = log ?? new DummyLog();
-            this.HttpMessageHandler = httpMessageHandler;            
+            this.HttpMessageHandler = httpMessageHandler;
+            this.AppendException = true;          
         }
 
         /// <summary>
@@ -94,6 +95,15 @@ namespace SumoLogic.Logging.NLog
         /// Gets or sets a value indicating whether the console log should be used.
         /// </summary>
         public bool UseConsoleLog
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the exception.ToString() should be automatically appended to the message being sent
+        /// </summary>
+        public bool AppendException
         {
             get;
             set;
@@ -188,7 +198,7 @@ namespace SumoLogic.Logging.NLog
             using (var textWriter = new StringWriter(bodyBuilder, CultureInfo.InvariantCulture))
             {
                 textWriter.Write(Layout.Render(logEvent));
-                if (logEvent.Exception != null)
+                if (logEvent.Exception != null && this.AppendException)
                 {
                     textWriter.Write(logEvent.Exception.ToString());
                 }


### PR DESCRIPTION
Hi

We are using the NLog json layout and are forming up the layout for our exceptions so that the message sent to sumo logic is a nice json string, though currently the sumologic nlog class automatically appends exception.ToString() to the end of the message.

We would like the ability to disable this so that the exception is not appended.

Thanks