### PR TITLE
Annotate NLog tests as being in the same xunit collection

### DIFF
--- a/SumoLogic.Logging.NLog.Tests/BufferedSumoLogicTargetTest.cs
+++ b/SumoLogic.Logging.NLog.Tests/BufferedSumoLogicTargetTest.cs
@@ -35,6 +35,7 @@ namespace SumoLogic.Logging.NLog.Tests
     /// <summary>
     /// Buffered Sumo Logic target test implementation.
     /// </summary>
+    [Collection("NLog tests")]
     public class BufferedSumoLogicTargetTest : IDisposable
     {
         /// <summary>

--- a/SumoLogic.Logging.NLog.Tests/SumoLogicTargetTest.cs
+++ b/SumoLogic.Logging.NLog.Tests/SumoLogicTargetTest.cs
@@ -35,6 +35,7 @@ namespace SumoLogic.Logging.NLog.Tests
     /// <summary>
     /// Sumo logic target test implementation.   
     /// </summary>
+    [Collection("NLog tests")]
     public class SumoLogicTargetTest : IDisposable
     {
         /// <summary>


### PR DESCRIPTION
When working on other PR, noticed that tests were not passing reliably.

Root cause is that nlog tests are not safe to run in parallel (global logger config
gets updated). Assigning the same xunit collection forces them to be run in serial.