### PR TITLE
NLog - retry sending for a broader set of error types

### DIFF
--- a/SumoLogic.Logging.Common/Sender/SumoLogicMessageSender.cs
+++ b/SumoLogic.Logging.Common/Sender/SumoLogicMessageSender.cs
@@ -131,7 +131,7 @@ namespace SumoLogic.Logging.Common.Sender
                 catch (Exception ex)
                 {
                     // only retry if we have a reasonable hope that the issue is transient
-                    if(!(ex is IOException || ex is HttpRequestException || ex is WebException))
+                    if (!(ex is IOException || ex is HttpRequestException || ex is WebException))
                     {
                         throw;
                     }

--- a/SumoLogic.Logging.Common/Sender/SumoLogicMessageSender.cs
+++ b/SumoLogic.Logging.Common/Sender/SumoLogicMessageSender.cs
@@ -128,8 +128,14 @@ namespace SumoLogic.Logging.Common.Sender
                     this.TrySend(body, name);
                     success = true;
                 }
-                catch (IOException ex)
+                catch (Exception ex)
                 {
+                    // only retry if we have a reasonable hope that the issue is transient
+                    if(!(ex is IOException || ex is HttpRequestException || ex is WebException))
+                    {
+                        throw;
+                    }
+
                     if (this.Log.IsErrorEnabled)
                     {
                         this.Log.Error("Error trying send messages. Exception: " + ex.Message);


### PR DESCRIPTION
Fixes https://github.com/SumoLogic/sumologic-net-appenders/issues/9

Expand the set of handled exceptions somewhat. I'd prefer not to catch all `Exception`, I would hope the new set covers the vast majority of cases where retry is a valid recovery approach.

Certainly if other specific exception types are later discovered to be possible in practice, we can grow this set.