### PR TITLE
Limit DrainTo to prevent unbounded draining

### DIFF
--- a/SumoLogic.Logging.Common.Tests/Queue/CostBoundedConcurrentQueueTest.cs
+++ b/SumoLogic.Logging.Common.Tests/Queue/CostBoundedConcurrentQueueTest.cs
@@ -27,6 +27,7 @@ namespace SumoLogic.Logging.Common.Tests.Queue
 {
     using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
+    using System.Threading;
     using SumoLogic.Logging.Common.Queue;
     using Xunit;
 
@@ -108,6 +109,44 @@ namespace SumoLogic.Logging.Common.Tests.Queue
         }
 
         /// <summary>
+        /// Drain queue while simultaneously writing into it
+        /// </summary>
+        [SuppressMessage("Microsoft.Performance", "CA1822:MarkMembersAsStatic", Justification = "Unit test")]
+        [Fact]
+        public void DrainToWithWritersTest()
+        {
+            var queue = new CostBoundedConcurrentQueue<string>(10000, new StringLengthCostAssigner());
+            for (int i = 0; i < 5000; i++)
+            {
+                queue.Enqueue(BuildStringOfSize(2));
+            }
+
+            Assert.Equal(10000, queue.Cost);
+
+            // start background writer that will attempt to enqueue
+            // new messages while we drain
+            var writerThread = StartBackgroundWriter(queue, 1, 7000);
+            Thread.Sleep(100);
+            var drainCollection = new List<string>();
+            queue.DrainTo(drainCollection);
+
+            // only the original 5000 messages should be drained, none
+            // of the newly-written messages
+            Assert.Equal(5000, drainCollection.Count);
+
+            // background writer should finish writing
+            Thread.Sleep(1000);
+            drainCollection.Clear();
+            queue.DrainTo(drainCollection);
+            Assert.Equal(7000, drainCollection.Count);
+
+            if (writerThread.IsAlive)
+            {
+                writerThread.Abort();
+            }
+        }
+
+        /// <summary>
         /// Builds a string with a length of 'n' characters.
         /// </summary>
         /// <param name="n">The string length.</param>
@@ -121,6 +160,33 @@ namespace SumoLogic.Logging.Common.Tests.Queue
             }
 
             return str;
+        }
+
+        /// <summary>
+        /// Starts a background thread that will aggressively write elements into the specified queue.
+        /// </summary>
+        /// <param name="queue">Queue into which elements should be written</param>
+        /// <param name="elementCost">Cost of each element</param>
+        /// <param name="howMany">How many total elements should be written</param>
+        /// <returns>The resultant thread. The thread will already be started.</returns>
+        private static Thread StartBackgroundWriter(CostBoundedConcurrentQueue<string> queue, int elementCost, int howMany)
+        {
+            Thread t = new Thread(new ThreadStart(() =>
+            {
+                var str = BuildStringOfSize(elementCost);
+
+                // spin as fast as possible, adding elements as soon as capacity becomes available
+                for (int i = 0; i < howMany; i++)
+                {
+                    while (!queue.Enqueue(str))
+                    {
+                    }
+                }
+            }));
+
+            t.Start();
+
+            return t;
         }
     }
 }

--- a/SumoLogic.Logging.Common/Queue/CostBoundedConcurrentQueue.cs
+++ b/SumoLogic.Logging.Common/Queue/CostBoundedConcurrentQueue.cs
@@ -88,29 +88,31 @@ namespace SumoLogic.Logging.Common.Queue
         }
 
         /// <summary>
-        /// Removes all available elements from this queue and adds them to the given collection.
+        /// Removes all available elements from this queue and adds them to the given collection,
+        /// up to a maximum total cost of <see cref="capacity"/>.
         /// </summary>
         /// <param name="collection">Destination collection.</param>
         /// <returns>The number of elements transferred.</returns>
         public int DrainTo(ICollection<T> collection)
         {
             int elementsDrained = 0;
+            long drainedCapacity = 0L;
 
             if (collection == null)
             {
                 throw new InvalidOperationException();
             }
-            else
+
+            while (!this.queue.IsEmpty && drainedCapacity < this.capacity)
             {
-                while (this.queue.IsEmpty != true)
+                T e;
+                if (this.queue.TryDequeue(out e))
                 {
-                    T e;
-                    if (this.queue.TryDequeue(out e) && collection != null)
-                    {
-                        collection.Add(e);
-                        Interlocked.Add(ref this.cost, -this.costAssigner.Cost(e));
-                        elementsDrained++;
-                    }
+                    collection.Add(e);
+                    long elementCost = this.costAssigner.Cost(e);
+                    Interlocked.Add(ref this.cost, -elementCost);
+                    drainedCapacity += elementCost;
+                    elementsDrained++;
                 }
             }
 


### PR DESCRIPTION
Ref https://github.com/SumoLogic/sumologic-net-appenders/issues/12

Queue was previously draining until it is empty - this might never happen (or not happen for a long time) if there is a writer simultaneously adding new elements to backfill capacity.  As noted in the issue, this could result in a big pile of data getting accumulated before sending to Sumo.

Proposed solution is to halt the drain once the total capacity of drained items matches the capacity of the queue itself (even if queue is not empty).