### PR TITLE
Timer update for .NET Standard prep

### DIFF
--- a/SumoLogic.Logging.Common.Tests/SumoLogic.Logging.Common.Tests.csproj
+++ b/SumoLogic.Logging.Common.Tests/SumoLogic.Logging.Common.Tests.csproj
@@ -97,6 +97,9 @@
       <Link>CustomDictionary.xml</Link>
     </CodeAnalysisDictionary>
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="..\packages\StyleCop.MSBuild.4.7.49.1\build\StyleCop.MSBuild.Targets" Condition="Exists('..\packages\StyleCop.MSBuild.4.7.49.1\build\StyleCop.MSBuild.Targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/SumoLogic.Logging.Common/Queue/BufferWithFifoEviction.cs
+++ b/SumoLogic.Logging.Common/Queue/BufferWithFifoEviction.cs
@@ -37,6 +37,12 @@ namespace SumoLogic.Logging.Common.Queue
     public class BufferWithFifoEviction<T> : BufferWithEviction<T>
     {
         /// <summary>
+        /// Lock object used when adding 
+        /// an element to the queue
+        /// </summary>
+        private readonly object queueAddLock = new object();
+
+        /// <summary>
         /// Cost bounded concurrent queue.
         /// </summary>
         private CostBoundedConcurrentQueue<T> queue;
@@ -104,17 +110,19 @@ namespace SumoLogic.Logging.Common.Queue
         /// </summary>
         /// <param name="element">Element to add in queue.</param>
         /// <returns>If it add was successful.</returns>
-        [MethodImpl(MethodImplOptions.Synchronized)]
         public override bool Add(T element)
         {
-            bool success = this.queue.Enqueue(element);
-            if (success == false)
+            lock (this.queueAddLock)
             {
-                this.Evict(this.costAssigner.Cost(element));
-                return this.queue.Enqueue(element);
-            }
+                bool success = this.queue.Enqueue(element);
+                if (success == false)
+                {
+                    this.Evict(this.costAssigner.Cost(element));
+                    return this.queue.Enqueue(element);
+                }
 
-            return true;
+                return true;
+            }
         }
 
         /// <summary>
@@ -149,7 +157,7 @@ namespace SumoLogic.Logging.Common.Queue
             }
 
             if (numEvicted > 0 && this.log.IsWarnEnabled)
-            {              
+            {
                 this.log.Warn("Evicted " + numEvicted + " messages from buffer");
             }
 

--- a/SumoLogic.Logging.Common/Queue/CostBoundedConcurrentQueue.cs
+++ b/SumoLogic.Logging.Common/Queue/CostBoundedConcurrentQueue.cs
@@ -39,6 +39,12 @@ namespace SumoLogic.Logging.Common.Queue
     public class CostBoundedConcurrentQueue<T>
     {
         /// <summary>
+        /// Lock object used when adding 
+        /// an element to the queue
+        /// </summary>
+        private readonly object enqueueLock = new object();
+
+        /// <summary>
         /// Concurrent queue.
         /// </summary>
         private ConcurrentQueue<T> queue;
@@ -132,7 +138,7 @@ namespace SumoLogic.Logging.Common.Queue
             long auxCost = this.costAssigner.Cost(element);
 
             // Atomically check capacity and optimistically increase usage
-            lock (this)
+            lock (this.enqueueLock)
             {
                 if (auxCost + this.Cost > this.capacity)
                 {

--- a/SumoLogic.Logging.Log4Net.Tests/BufferedSumoLogicAppenderTest.cs
+++ b/SumoLogic.Logging.Log4Net.Tests/BufferedSumoLogicAppenderTest.cs
@@ -171,7 +171,7 @@ namespace SumoLogic.Logging.Log4Net.Tests
         /// <param name="maxFlushInterval">The maximum flush interval, in milliseconds.</param>
         /// <param name="flushingAccuracy">The flushing accuracy, in milliseconds.</param>
         /// <param name="retryInterval">The retry interval, in milliseconds.</param>
-        private void SetUpLogger(long messagesPerRequest, long maxFlushInterval, long flushingAccuracy, long retryInterval = 10000)
+        private void SetUpLogger(long messagesPerRequest, long maxFlushInterval, int flushingAccuracy, long retryInterval = 10000)
         {
             this.messagesHandler = new MockHttpMessageHandler();
 

--- a/SumoLogic.Logging.Log4Net.Tests/SumoLogic.Logging.Log4Net.Tests.csproj
+++ b/SumoLogic.Logging.Log4Net.Tests/SumoLogic.Logging.Log4Net.Tests.csproj
@@ -107,6 +107,9 @@
   <ItemGroup>
     <Compile Include="SumoLogicAppenderTest.cs" />
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="..\packages\StyleCop.MSBuild.4.7.49.1\build\StyleCop.MSBuild.Targets" Condition="Exists('..\packages\StyleCop.MSBuild.4.7.49.1\build\StyleCop.MSBuild.Targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/SumoLogic.Logging.NLog.Tests/BufferedSumoLogicTargetTest.cs
+++ b/SumoLogic.Logging.NLog.Tests/BufferedSumoLogicTargetTest.cs
@@ -164,7 +164,7 @@ namespace SumoLogic.Logging.NLog.Tests
         /// <param name="maxFlushInterval">The maximum flush interval, in milliseconds.</param>
         /// <param name="flushingAccuracy">The flushing accuracy, in milliseconds.</param>
         /// <param name="retryInterval">The retry interval, in milliseconds.</param>
-        private void SetUpLogger(long messagesPerRequest, long maxFlushInterval, long flushingAccuracy, long retryInterval = 10000)
+        private void SetUpLogger(long messagesPerRequest, long maxFlushInterval, int flushingAccuracy, long retryInterval = 10000)
         {
             this.messagesHandler = new MockHttpMessageHandler();
             this.bufferedSumoLogicTarget = new BufferedSumoLogicTarget(null, this.messagesHandler);

--- a/SumoLogic.Logging.NLog.Tests/SumoLogic.Logging.NLog.Tests.csproj
+++ b/SumoLogic.Logging.NLog.Tests/SumoLogic.Logging.NLog.Tests.csproj
@@ -106,6 +106,9 @@
       <Link>CustomDictionary.xml</Link>
     </CodeAnalysisDictionary>
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="..\packages\StyleCop.MSBuild.4.7.49.1\build\StyleCop.MSBuild.Targets" Condition="Exists('..\packages\StyleCop.MSBuild.4.7.49.1\build\StyleCop.MSBuild.Targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/SumoLogic.Logging.NLog/BufferedSumoLogicTarget.cs
+++ b/SumoLogic.Logging.NLog/BufferedSumoLogicTarget.cs
@@ -23,6 +23,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 namespace SumoLogic.Logging.NLog
 {
     using System;
@@ -31,7 +32,7 @@ namespace SumoLogic.Logging.NLog
     using System.IO;
     using System.Net.Http;
     using System.Text;
-    using System.Timers;
+    using System.Threading;
     using global::NLog;
     using global::NLog.Targets;
     using SumoLogic.Logging.Common.Log;
@@ -125,7 +126,7 @@ namespace SumoLogic.Logging.NLog
         /// <summary>
         /// Gets or sets how often the messages queue is checked for messages to send, in milliseconds.
         /// </summary>
-        public long FlushingAccuracy
+        public int FlushingAccuracy
         {
             get;
             set;
@@ -254,7 +255,6 @@ namespace SumoLogic.Logging.NLog
             // Initialize flusher
             if (this.flushBufferTimer != null)
             {
-                this.flushBufferTimer.Stop();
                 this.flushBufferTimer.Dispose();
             }
 
@@ -272,10 +272,12 @@ namespace SumoLogic.Logging.NLog
                 this.SourceName,
                 this.LogLog);
 
-            this.flushBufferTimer = new Timer(TimeSpan.FromMilliseconds(this.FlushingAccuracy).TotalMilliseconds);
-            this.flushBufferTimer.Elapsed += (s, e) => this.flushBufferTask.Run();
+            TimerCallback timerCallback = state =>
+            {
+                flushBufferTask.Run();
+            };
 
-            this.flushBufferTimer.Start();
+            this.flushBufferTimer = new Timer(timerCallback, null, 0, this.FlushingAccuracy);
         }
 
         /// <summary>
@@ -332,7 +334,6 @@ namespace SumoLogic.Logging.NLog
 
             if (this.flushBufferTimer != null)
             {
-                this.flushBufferTimer.Stop();
                 this.flushBufferTimer.Dispose();
                 this.flushBufferTimer = null;
             }


### PR DESCRIPTION
Taken from https://msdn.microsoft.com/en-us/library/system.timers.timer(v=vs.110).aspx

> The Timer class is available in the .NET Framework only. It is not included in the .NET Standard Library and is not available on other platforms, such as .NET Core or the Universal Windows Platform. On these platforms, as well as for portability across all .NET platforms, you should use the System.Threading.Timer class instead.

This PR is for .NET Standard prepping and addresses the above.
