### PR TITLE
Netstandard prep/thread sleep exception

### DIFF
--- a/SumoLogic.Logging.Common.Tests/SumoLogic.Logging.Common.Tests.csproj
+++ b/SumoLogic.Logging.Common.Tests/SumoLogic.Logging.Common.Tests.csproj
@@ -97,6 +97,9 @@
       <Link>CustomDictionary.xml</Link>
     </CodeAnalysisDictionary>
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="..\packages\StyleCop.MSBuild.4.7.49.1\build\StyleCop.MSBuild.Targets" Condition="Exists('..\packages\StyleCop.MSBuild.4.7.49.1\build\StyleCop.MSBuild.Targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/SumoLogic.Logging.Common/Queue/BufferWithFifoEviction.cs
+++ b/SumoLogic.Logging.Common/Queue/BufferWithFifoEviction.cs
@@ -37,6 +37,12 @@ namespace SumoLogic.Logging.Common.Queue
     public class BufferWithFifoEviction<T> : BufferWithEviction<T>
     {
         /// <summary>
+        /// Lock object used when adding 
+        /// an element to the queue
+        /// </summary>
+        private readonly object queueAddLock = new object();
+
+        /// <summary>
         /// Cost bounded concurrent queue.
         /// </summary>
         private CostBoundedConcurrentQueue<T> queue;
@@ -104,17 +110,19 @@ namespace SumoLogic.Logging.Common.Queue
         /// </summary>
         /// <param name="element">Element to add in queue.</param>
         /// <returns>If it add was successful.</returns>
-        [MethodImpl(MethodImplOptions.Synchronized)]
         public override bool Add(T element)
         {
-            bool success = this.queue.Enqueue(element);
-            if (success == false)
+            lock (this.queueAddLock)
             {
-                this.Evict(this.costAssigner.Cost(element));
-                return this.queue.Enqueue(element);
-            }
+                bool success = this.queue.Enqueue(element);
+                if (success == false)
+                {
+                    this.Evict(this.costAssigner.Cost(element));
+                    return this.queue.Enqueue(element);
+                }
 
-            return true;
+                return true;
+            }
         }
 
         /// <summary>
@@ -149,7 +157,7 @@ namespace SumoLogic.Logging.Common.Queue
             }
 
             if (numEvicted > 0 && this.log.IsWarnEnabled)
-            {              
+            {
                 this.log.Warn("Evicted " + numEvicted + " messages from buffer");
             }
 

--- a/SumoLogic.Logging.Common/Queue/CostBoundedConcurrentQueue.cs
+++ b/SumoLogic.Logging.Common/Queue/CostBoundedConcurrentQueue.cs
@@ -39,6 +39,12 @@ namespace SumoLogic.Logging.Common.Queue
     public class CostBoundedConcurrentQueue<T>
     {
         /// <summary>
+        /// Lock object used when adding 
+        /// an element to the queue
+        /// </summary>
+        private readonly object enqueueLock = new object();
+
+        /// <summary>
         /// Concurrent queue.
         /// </summary>
         private ConcurrentQueue<T> queue;
@@ -132,7 +138,7 @@ namespace SumoLogic.Logging.Common.Queue
             long auxCost = this.costAssigner.Cost(element);
 
             // Atomically check capacity and optimistically increase usage
-            lock (this)
+            lock (this.enqueueLock)
             {
                 if (auxCost + this.Cost > this.capacity)
                 {

--- a/SumoLogic.Logging.Common/Sender/SumoLogicMessageSender.cs
+++ b/SumoLogic.Logging.Common/Sender/SumoLogicMessageSender.cs
@@ -145,7 +145,7 @@ namespace SumoLogic.Logging.Common.Sender
                     {
                         Thread.Sleep(this.RetryInterval);
                     }
-                    catch (ThreadInterruptedException ex2)
+                    catch (Exception ex2)
                     {
                         if (this.Log.IsErrorEnabled)
                         {

--- a/SumoLogic.Logging.Log4Net.Tests/SumoLogic.Logging.Log4Net.Tests.csproj
+++ b/SumoLogic.Logging.Log4Net.Tests/SumoLogic.Logging.Log4Net.Tests.csproj
@@ -107,6 +107,9 @@
   <ItemGroup>
     <Compile Include="SumoLogicAppenderTest.cs" />
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="..\packages\StyleCop.MSBuild.4.7.49.1\build\StyleCop.MSBuild.Targets" Condition="Exists('..\packages\StyleCop.MSBuild.4.7.49.1\build\StyleCop.MSBuild.Targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/SumoLogic.Logging.NLog.Tests/SumoLogic.Logging.NLog.Tests.csproj
+++ b/SumoLogic.Logging.NLog.Tests/SumoLogic.Logging.NLog.Tests.csproj
@@ -106,6 +106,9 @@
       <Link>CustomDictionary.xml</Link>
     </CodeAnalysisDictionary>
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="..\packages\StyleCop.MSBuild.4.7.49.1\build\StyleCop.MSBuild.Targets" Condition="Exists('..\packages\StyleCop.MSBuild.4.7.49.1\build\StyleCop.MSBuild.Targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">


### PR DESCRIPTION
Catch any exception thrown on Thread.Sleep since ThreadInterruptedException is not currently supported in .NET Standard