### PR TITLE
Locking on a private dummy object to conform to correct usage of locking

### DIFF
--- a/SumoLogic.Logging.Common/Queue/CostBoundedConcurrentQueue.cs
+++ b/SumoLogic.Logging.Common/Queue/CostBoundedConcurrentQueue.cs
@@ -39,6 +39,12 @@ namespace SumoLogic.Logging.Common.Queue
     public class CostBoundedConcurrentQueue<T>
     {
         /// <summary>
+        /// Lock object used when adding 
+        /// an element to the queue
+        /// </summary>
+        private readonly object enqueueLock = new object();
+
+        /// <summary>
         /// Concurrent queue.
         /// </summary>
         private ConcurrentQueue<T> queue;
@@ -132,7 +138,7 @@ namespace SumoLogic.Logging.Common.Queue
             long auxCost = this.costAssigner.Cost(element);
 
             // Atomically check capacity and optimistically increase usage
-            lock (this)
+            lock (this.enqueueLock)
             {
                 if (auxCost + this.Cost > this.capacity)
                 {


### PR DESCRIPTION
To prevent potential dead locks, it is recommended to not use MethodImplOptions.Synchronized nor lock(this). Instead, you should lock on a private dummy object.

See here for more info: https://blogs.msdn.microsoft.com/bclteam/2004/01/20/lock-vs-methodimploptions-synchronized-kit-george/