### PR TITLE
Update versions and package metadata

### DIFF
--- a/SumoLogic.Logging.Common.Tests/Properties/AssemblyInfo.cs
+++ b/SumoLogic.Logging.Common.Tests/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("SumoLogic.Logging.Common.Tests")]
-[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyCopyright("Copyright ©  2017")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/SumoLogic.Logging.Common/SumoLogic.Logging.Common.csproj
+++ b/SumoLogic.Logging.Common/SumoLogic.Logging.Common.csproj
@@ -13,9 +13,9 @@
   <PropertyGroup>
     <PackageId>SumoLogic.Logging.Common</PackageId>
     <PackageVersion>1.0.0.3</PackageVersion>
-    <Description>SumoLogic core library</Description>
-    <Authors>SumoLogic</Authors>
-    <Copyright>Copyright © 2015 Sumo Logic Inc. - All Rights Reserved</Copyright>
+    <Description>Shared library used by .NET log appenders uploading to Sumo Logic.</Description>
+    <Authors>Sumo Logic</Authors>
+    <Copyright>Copyright © 2017 Sumo Logic Inc. - All Rights Reserved</Copyright>
     <TargetFrameworks>netstandard1.1;net45</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
   </PropertyGroup>

--- a/SumoLogic.Logging.Common/SumoLogic.Logging.Common.csproj
+++ b/SumoLogic.Logging.Common/SumoLogic.Logging.Common.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <PackageId>SumoLogic.Logging.Common</PackageId>
-    <PackageVersion>1.0.0.3</PackageVersion>
+    <PackageVersion>1.0.0.4</PackageVersion>
     <Description>Shared library used by .NET log appenders uploading to Sumo Logic.</Description>
     <Authors>Sumo Logic</Authors>
     <Copyright>Copyright © 2017 Sumo Logic Inc. - All Rights Reserved</Copyright>

--- a/SumoLogic.Logging.EnterpriseLibrary.Tests/Properties/AssemblyInfo.cs
+++ b/SumoLogic.Logging.EnterpriseLibrary.Tests/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("SumoLogic.Logging.EnterpriseLibrary.Tests")]
-[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyCopyright("Copyright ©  2017")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/SumoLogic.Logging.EnterpriseLibrary/Properties/AssemblyInfo.cs
+++ b/SumoLogic.Logging.EnterpriseLibrary/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("SumoLogic.Logging.EnterpriseLibrary")]
-[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyCopyright("Copyright ©  2017")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/SumoLogic.Logging.Log4Net.Example/Properties/AssemblyInfo.cs
+++ b/SumoLogic.Logging.Log4Net.Example/Properties/AssemblyInfo.cs
@@ -11,7 +11,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("SumoLogic.Logging.Log4Net.Example")]
-[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyCopyright("Copyright ©  2017")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/SumoLogic.Logging.Log4Net.Tests/Properties/AssemblyInfo.cs
+++ b/SumoLogic.Logging.Log4Net.Tests/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("SumoLogic.Logging.Log4Net.Tests")]
-[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyCopyright("Copyright ©  2017")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/SumoLogic.Logging.Log4Net/SumoLogic.Logging.Log4Net.csproj
+++ b/SumoLogic.Logging.Log4Net/SumoLogic.Logging.Log4Net.csproj
@@ -15,7 +15,7 @@
     <Version>1.0.0.3</Version>
     <Description>SumoLogic provides an interface between log4Net and remote sevice Logging.</Description>
     <Authors>SumoLogic</Authors>
-    <Copyright>Copyright © 2015 Sumo Logic Inc. - All Rights Reserved</Copyright>
+    <Copyright>Copyright © 2017 Sumo Logic Inc. - All Rights Reserved</Copyright>
     <TargetFrameworks>netstandard1.3;net45</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
   </PropertyGroup>

--- a/SumoLogic.Logging.Log4Net/SumoLogic.Logging.Log4Net.csproj
+++ b/SumoLogic.Logging.Log4Net/SumoLogic.Logging.Log4Net.csproj
@@ -13,8 +13,8 @@
   <PropertyGroup>
     <PackageId>SumoLogic.Logging.Log4Net</PackageId>
     <Version>1.0.0.3</Version>
-    <Description>SumoLogic provides an interface between log4Net and remote sevice Logging.</Description>
-    <Authors>SumoLogic</Authors>
+    <Description>Log4Net appender which sends logs to the Sumo Logic machine data analytics platform.</Description>
+    <Authors>Sumo Logic</Authors>
     <Copyright>Copyright © 2017 Sumo Logic Inc. - All Rights Reserved</Copyright>
     <TargetFrameworks>netstandard1.3;net45</TargetFrameworks>
     <SignAssembly>true</SignAssembly>

--- a/SumoLogic.Logging.Log4Net/SumoLogic.Logging.Log4Net.csproj
+++ b/SumoLogic.Logging.Log4Net/SumoLogic.Logging.Log4Net.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <PackageId>SumoLogic.Logging.Log4Net</PackageId>
-    <Version>1.0.0.3</Version>
+    <Version>1.0.0.4</Version>
     <Description>Log4Net appender which sends logs to the Sumo Logic machine data analytics platform.</Description>
     <Authors>Sumo Logic</Authors>
     <Copyright>Copyright © 2017 Sumo Logic Inc. - All Rights Reserved</Copyright>

--- a/SumoLogic.Logging.NLog.Example/Properties/AssemblyInfo.cs
+++ b/SumoLogic.Logging.NLog.Example/Properties/AssemblyInfo.cs
@@ -11,7 +11,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("SumoLogic.Logging.NLog.Example")]
-[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyCopyright("Copyright ©  2017")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/SumoLogic.Logging.NLog.Tests/Properties/AssemblyInfo.cs
+++ b/SumoLogic.Logging.NLog.Tests/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("SumoLogic.Logging.NLog.Tests")]
-[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyCopyright("Copyright ©  2017")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/SumoLogic.Logging.NLog/SumoLogic.Logging.NLog.csproj
+++ b/SumoLogic.Logging.NLog/SumoLogic.Logging.NLog.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <PackageId>SumoLogic.Logging.NLog</PackageId>
-    <Version>1.0.0.3-beta1</Version>
+    <Version>1.0.0.4-beta1</Version>
     <Description>NLog appender which sends logs to the Sumo Logic machine data platform.</Description>
     <Authors>Sumo Logic</Authors>
     <Copyright>Copyright © 2017 Sumo Logic Inc. - All Rights Reserved</Copyright>

--- a/SumoLogic.Logging.NLog/SumoLogic.Logging.NLog.csproj
+++ b/SumoLogic.Logging.NLog/SumoLogic.Logging.NLog.csproj
@@ -15,7 +15,7 @@
     <Version>1.0.0.3-beta1</Version>
     <Description>SumoLogic provides an interface between NLog and remote sevice Logging.</Description>
     <Authors>SumoLogic</Authors>
-    <Copyright>Copyright © 2015 Sumo Logic Inc. - All Rights Reserved</Copyright>
+    <Copyright>Copyright © 2017 Sumo Logic Inc. - All Rights Reserved</Copyright>
     <TargetFrameworks>net45;netstandard1.5</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
   </PropertyGroup>

--- a/SumoLogic.Logging.NLog/SumoLogic.Logging.NLog.csproj
+++ b/SumoLogic.Logging.NLog/SumoLogic.Logging.NLog.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <PackageId>SumoLogic.Logging.NLog</PackageId>
-    <Version>1.0.0.3</Version>
+    <Version>1.0.0.3-beta1</Version>
     <Description>SumoLogic provides an interface between NLog and remote sevice Logging.</Description>
     <Authors>SumoLogic</Authors>
     <Copyright>Copyright © 2015 Sumo Logic Inc. - All Rights Reserved</Copyright>

--- a/SumoLogic.Logging.NLog/SumoLogic.Logging.NLog.csproj
+++ b/SumoLogic.Logging.NLog/SumoLogic.Logging.NLog.csproj
@@ -13,8 +13,8 @@
   <PropertyGroup>
     <PackageId>SumoLogic.Logging.NLog</PackageId>
     <Version>1.0.0.3-beta1</Version>
-    <Description>SumoLogic provides an interface between NLog and remote sevice Logging.</Description>
-    <Authors>SumoLogic</Authors>
+    <Description>NLog appender which sends logs to the Sumo Logic machine data platform.</Description>
+    <Authors>Sumo Logic</Authors>
     <Copyright>Copyright © 2017 Sumo Logic Inc. - All Rights Reserved</Copyright>
     <TargetFrameworks>net45;netstandard1.5</TargetFrameworks>
     <SignAssembly>true</SignAssembly>


### PR DESCRIPTION
Set package versions to 1.0.0.4 across the board. We had already shipped a 1.0.0.3 for the Log4Net package, so skip over that version on the others.

Note that NLog appender is relying on pre-release nlog core package 5.0.0-beta07, so we are setting our own version to 1.0.0.4-beta1 for this, to indicate that our package is also pre-release.

Also minor fixes to package metadata text.