### PR TITLE
implicit std version 1.6.0 

### DIFF
--- a/SumoLogic.Logging.Common/SumoLogic.Logging.Common.csproj
+++ b/SumoLogic.Logging.Common/SumoLogic.Logging.Common.csproj
@@ -21,6 +21,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <AssemblyOriginatorKeyFile>..\SumoLogic.Logging.snk</AssemblyOriginatorKeyFile>
+    <NetStandardImplicitPackageVersion>1.6.0</NetStandardImplicitPackageVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net45' ">
     <DefineConstants>netfull</DefineConstants>

--- a/SumoLogic.Logging.Log4Net/SumoLogic.Logging.Log4Net.csproj
+++ b/SumoLogic.Logging.Log4Net/SumoLogic.Logging.Log4Net.csproj
@@ -24,6 +24,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <AssemblyOriginatorKeyFile>..\SumoLogic.Logging.snk</AssemblyOriginatorKeyFile>
+    <NetStandardImplicitPackageVersion>1.6.0</NetStandardImplicitPackageVersion>
   </PropertyGroup>
   <ItemGroup>
     <None Include="..\SumoLogic.Logging.snk">

--- a/SumoLogic.Logging.NLog/SumoLogic.Logging.NLog.csproj
+++ b/SumoLogic.Logging.NLog/SumoLogic.Logging.NLog.csproj
@@ -21,6 +21,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <AssemblyOriginatorKeyFile>..\SumoLogic.Logging.snk</AssemblyOriginatorKeyFile>
+    <NetStandardImplicitPackageVersion>1.6.0</NetStandardImplicitPackageVersion>
   </PropertyGroup>
   <ItemGroup>
     <None Include="..\SumoLogic.Logging.snk">


### PR DESCRIPTION
#40

Since nuget uses semvar we might as well target 1.6.0 things that need 1.6.1 will just use it and be ok, but the reverse won't happen and right now we target 1.6.1