### PR TITLE
Add value to X-Sumo-Client header on each request

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ SumoLogic.Logging.Nuget/
 packages/
 !packages/repositories.config
 .vscode
+.vs

--- a/SumoLogic.Logging.Common.Tests/Sender/SumoLogicMessageSenderTest.cs
+++ b/SumoLogic.Logging.Common.Tests/Sender/SumoLogicMessageSenderTest.cs
@@ -56,7 +56,7 @@ namespace SumoLogic.Logging.Common.Tests.Http
         public SumoLogicMessageSenderTest()
         {
             this.messagesHandler = new MockHttpMessageHandler();
-            this.sumoLogicMessageSender = new SumoLogicMessageSender(this.messagesHandler, null);
+            this.sumoLogicMessageSender = new SumoLogicMessageSender(this.messagesHandler, null, "sumo-test");
             this.sumoLogicMessageSender.Url = new Uri("http://www.fakeadress.com");
             this.sumoLogicMessageSender.RetryInterval = TimeSpan.FromSeconds(30);
         }
@@ -84,6 +84,7 @@ namespace SumoLogic.Logging.Common.Tests.Http
             Assert.Equal("name", this.messagesHandler.LastReceivedRequest.Content.Headers.GetValues("X-Sumo-Name").First<string>());
             Assert.Equal("category", this.messagesHandler.LastReceivedRequest.Content.Headers.GetValues("X-Sumo-Category").First<string>());
             Assert.Equal("host", this.messagesHandler.LastReceivedRequest.Content.Headers.GetValues("X-Sumo-Host").First<string>());
+            Assert.Equal("sumo-test", this.messagesHandler.LastReceivedRequest.Content.Headers.GetValues("X-Sumo-Client").First<string>());
         }
 
         /// <summary>

--- a/SumoLogic.Logging.Common/Sender/SumoLogicMessageSender.cs
+++ b/SumoLogic.Logging.Common/Sender/SumoLogicMessageSender.cs
@@ -52,7 +52,7 @@ namespace SumoLogic.Logging.Common.Sender
         /// </summary>
         /// <param name="httpMessageHandler">The HTTP message handler.</param>
         /// <param name="log">The log service.</param>
-        public SumoLogicMessageSender(HttpMessageHandler httpMessageHandler, ILog log) : this(httpMessageHandler, log, "net-message-sender")
+        public SumoLogicMessageSender(HttpMessageHandler httpMessageHandler, ILog log) : this(httpMessageHandler, log, "sumo-net-sender")
         {
         }
 

--- a/SumoLogic.Logging.Common/Sender/SumoLogicMessageSender.cs
+++ b/SumoLogic.Logging.Common/Sender/SumoLogicMessageSender.cs
@@ -45,15 +45,27 @@ namespace SumoLogic.Logging.Common.Sender
         private const string SUMO_SOURCE_NAME_HEADER = "X-Sumo-Name";
         private const string SUMO_SOURCE_CATEGORY_HEADER = "X-Sumo-Category";
         private const string SUMO_SOURCE_HOST_HEADER = "X-Sumo-Host";
+        private const string SUMO_CLIENT_HEADER = "X-Sumo-Client";
 
         /// <summary>
         /// Initializes a new instance of the <see cref="SumoLogicMessageSender" /> class.
         /// </summary>
         /// <param name="httpMessageHandler">The HTTP message handler.</param>
         /// <param name="log">The log service.</param>
-        public SumoLogicMessageSender(HttpMessageHandler httpMessageHandler, ILog log)
+        public SumoLogicMessageSender(HttpMessageHandler httpMessageHandler, ILog log) : this(httpMessageHandler, log, "net-message-sender")
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SumoLogicMessageSender" /> class.
+        /// </summary>
+        /// <param name="httpMessageHandler">The HTTP message handler.</param>
+        /// <param name="log">The log service.</param>
+        /// <param name="clientName">The name of the current client, for telemetry purposes.</param>
+        public SumoLogicMessageSender(HttpMessageHandler httpMessageHandler, ILog log, string clientName)
         {
             this.Log = log ?? new DummyLog();
+            this.ClientName = clientName;
             this.HttpClient = httpMessageHandler == null ? new HttpClient() : new HttpClient(httpMessageHandler);
         }
 
@@ -100,6 +112,15 @@ namespace SumoLogic.Logging.Common.Sender
         public bool CanSend
         {
             get { return this.Url != null && this.RetryInterval != TimeSpan.Zero && this.ConnectionTimeout != TimeSpan.Zero; }
+        }
+
+        /// <summary>
+        /// Gets or sets the client name value that is included in each request. This value is used for telemetry purposes to track usage of different clients.
+        /// </summary>
+        public string ClientName
+        {
+            get;
+            set;
         }
 
         /// <summary>
@@ -211,6 +232,10 @@ namespace SumoLogic.Logging.Common.Sender
                 if (!String.IsNullOrWhiteSpace(host))
                 {
                     httpContent.Headers.Add(SUMO_SOURCE_HOST_HEADER, host);
+                }
+                if (!String.IsNullOrWhiteSpace(ClientName))
+                {
+                    httpContent.Headers.Add(SUMO_CLIENT_HEADER, ClientName);
                 }
                 try
                 {

--- a/SumoLogic.Logging.Log4Net/BufferedSumoLogicAppender.cs
+++ b/SumoLogic.Logging.Log4Net/BufferedSumoLogicAppender.cs
@@ -241,7 +241,7 @@ namespace SumoLogic.Logging.Log4Net
             // Initialize the sender
             if (this.SumoLogicMessageSender == null)
             {
-                this.SumoLogicMessageSender = new SumoLogicMessageSender(this.HttpMessageHandler, this.LogLog);
+                this.SumoLogicMessageSender = new SumoLogicMessageSender(this.HttpMessageHandler, this.LogLog, "sumo-log4net-buffered-sender");
             }
 
             this.SumoLogicMessageSender.RetryInterval = TimeSpan.FromMilliseconds(this.RetryInterval);

--- a/SumoLogic.Logging.Log4Net/SumoLogicAppender.cs
+++ b/SumoLogic.Logging.Log4Net/SumoLogicAppender.cs
@@ -168,7 +168,7 @@ namespace SumoLogic.Logging.Log4Net
             // Initialize the sender
             if (this.SumoLogicMessageSender == null)
             {
-                this.SumoLogicMessageSender = new SumoLogicMessageSender(this.HttpMessageHandler, this.LogLog);
+                this.SumoLogicMessageSender = new SumoLogicMessageSender(this.HttpMessageHandler, this.LogLog, "sumo-log4net-sender");
             }
 
             this.SumoLogicMessageSender.ConnectionTimeout = TimeSpan.FromMilliseconds(this.ConnectionTimeout);

--- a/SumoLogic.Logging.NLog/BufferedSumoLogicTarget.cs
+++ b/SumoLogic.Logging.NLog/BufferedSumoLogicTarget.cs
@@ -266,7 +266,7 @@ namespace SumoLogic.Logging.NLog
             // Initialize the sender
             if (this.SumoLogicMessageSender == null)
             {
-                this.SumoLogicMessageSender = new SumoLogicMessageSender(this.HttpMessageHandler, this.LogLog);
+                this.SumoLogicMessageSender = new SumoLogicMessageSender(this.HttpMessageHandler, this.LogLog, "sumo-nlog-buffered-sender");
             }
 
             this.SumoLogicMessageSender.RetryInterval = TimeSpan.FromMilliseconds(this.RetryInterval);

--- a/SumoLogic.Logging.NLog/SumoLogicTarget.cs
+++ b/SumoLogic.Logging.NLog/SumoLogicTarget.cs
@@ -188,7 +188,7 @@ namespace SumoLogic.Logging.NLog
             // Initialize the sender
             if (this.SumoLogicMessageSender == null)
             {
-                this.SumoLogicMessageSender = new SumoLogicMessageSender(this.HttpMessageHandler, this.LogLog);
+                this.SumoLogicMessageSender = new SumoLogicMessageSender(this.HttpMessageHandler, this.LogLog, "sumo-nlog-sender");
             }
 
             this.SumoLogicMessageSender.ConnectionTimeout = TimeSpan.FromMilliseconds(this.ConnectionTimeout);


### PR DESCRIPTION
We are trying to gather statistics and telemetry around usage of Sumo's various open source collection plugins. This is being done by populating the `X-Sumo-Client` header on each request, with a string that uniquely identifies each of the clients we maintain at https://github.com/SumoLogic.

This change wires up that head for the .NET appenders.