### PR TITLE
normalize whitespace to spaces in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,37 +30,36 @@ PM> Install-Package SumoLogic.Logging.NLog
 ```
 <?xml version="1.0" encoding="utf-8" ?>
 <nlog autoReload="true" internalLogToConsole="true">
-	<extensions>
-		<add assembly="SumoLogic.Logging.NLog"/>
-	</extensions>
-	<targets>
-		<target name="sumoLogic" type="SumoLogicTarget"	layout="${date:format=yyyy-MM-dd HH\:mm\:ss.fff} ${level}, ${message}">
-			<Url>https://collectors.us2.sumologic.com/receiver/v1/http/ZaVnC4dhaV2dpl93h4mEkdCBwxHuX5fI1Yh_75Lhk8GtiMxsATMRTuebaZTDknk5dlFvjvYI7ZvraaHaA2NPq-O4v9bKZSTaMEZ_qHYxQ_ICBlWAonxtGA==</Url>
-			<ConnectionTimeout>30000</ConnectionTimeout>
-			<SourceName>ExampleNameNLogTarget</SourceName>
-			<SourceCategory>ExampleCategoryNLogTarget</SourceCategory>
-			<SourceHost>ExampleHostNLogTarget</SourceHost>
-			<UseConsoleLog>true</UseConsoleLog>
-		</target>
-		<target name="bufferedSumoLogic" type="BufferedSumoLogicTarget" layout="${date:format=yyyy-MM-dd HH\:mm\:ss.fff} ${level}, ${message}">
-			<Url>https://collectors.us2.sumologic.com/receiver/v1/http/ZaVnC4dhaV2dpl93h4mEkdCBwxHuX5fI1Yh_75Lhk8GtiMxsATMRTuebaZTDknk5dlFvjvYI7ZvraaHaA2NPq-O4v9bKZSTaMEZ_qHYxQ_ICBlWAonxtGA==</Url>
-			<SourceName>ExampleNameNLogBufferedTarget</SourceName>
-			<SourceCategory>ExampleCategoryNLogBufferedTarget</SourceCategory>
-			<SourceHost>ExampleHostNLogBufferedTarget</SourceHost>
-			<ConnectionTimeout>30000</ConnectionTimeout>
-			<RetryInterval>5000</RetryInterval>
-			<MessagesPerRequest>10</MessagesPerRequest>
-			<MaxFlushInterval>10000</MaxFlushInterval>
-			<FlushingAccuracy>250</FlushingAccuracy>
-			<MaxQueueSizeBytes>500000</MaxQueueSizeBytes>
-			<UseConsoleLog>true</UseConsoleLog>
-		</target>
-	</targets>
-	<rules>
-		<logger name="*" minLevel="Debug" writeTo="sumoLogic"/>
-		<logger name="*" minLevel="Debug" writeTo="bufferedSumoLogic"/>
-	</rules>
-
+  <extensions>
+    <add assembly="SumoLogic.Logging.NLog"/>
+  </extensions>
+  <targets>
+    <target name="sumoLogic" type="SumoLogicTarget"	layout="${date:format=yyyy-MM-dd HH\:mm\:ss.fff} ${level}, ${message}">
+      <Url>https://collectors.us2.sumologic.com/receiver/v1/http/ZaVnC4dhaV2dpl93h4mEkdCBwxHuX5fI1Yh_75Lhk8GtiMxsATMRTuebaZTDknk5dlFvjvYI7ZvraaHaA2NPq-O4v9bKZSTaMEZ_qHYxQ_ICBlWAonxtGA==</Url>
+      <ConnectionTimeout>30000</ConnectionTimeout>
+      <SourceName>ExampleNameNLogTarget</SourceName>
+      <SourceCategory>ExampleCategoryNLogTarget</SourceCategory>
+      <SourceHost>ExampleHostNLogTarget</SourceHost>
+      <UseConsoleLog>true</UseConsoleLog>
+    </target>
+    <target name="bufferedSumoLogic" type="BufferedSumoLogicTarget" layout="${date:format=yyyy-MM-dd HH\:mm\:ss.fff} ${level}, ${message}">
+      <Url>https://collectors.us2.sumologic.com/receiver/v1/http/ZaVnC4dhaV2dpl93h4mEkdCBwxHuX5fI1Yh_75Lhk8GtiMxsATMRTuebaZTDknk5dlFvjvYI7ZvraaHaA2NPq-O4v9bKZSTaMEZ_qHYxQ_ICBlWAonxtGA==</Url>
+      <SourceName>ExampleNameNLogBufferedTarget</SourceName>
+      <SourceCategory>ExampleCategoryNLogBufferedTarget</SourceCategory>
+      <SourceHost>ExampleHostNLogBufferedTarget</SourceHost>
+      <ConnectionTimeout>30000</ConnectionTimeout>
+      <RetryInterval>5000</RetryInterval>
+      <MessagesPerRequest>10</MessagesPerRequest>
+      <MaxFlushInterval>10000</MaxFlushInterval>
+      <FlushingAccuracy>250</FlushingAccuracy>
+      <MaxQueueSizeBytes>500000</MaxQueueSizeBytes>
+      <UseConsoleLog>true</UseConsoleLog>
+    </target>
+  </targets>
+  <rules>
+    <logger name="*" minLevel="Debug" writeTo="sumoLogic"/>
+    <logger name="*" minLevel="Debug" writeTo="bufferedSumoLogic"/>
+  </rules>
 </nlog>
 ```
 
@@ -68,15 +67,15 @@ PM> Install-Package SumoLogic.Logging.NLog
 ```csharp
 public static class Program
 {
-  /// <summary>
-  /// An example application that logs.
-  /// </summary>
-  public static void Main()
-  {
-    Logger logger = LogManager.GetCurrentClassLogger();
-    logger.Debug("Log message");
-    Console.Read();
-  }
+    /// <summary>
+    /// An example application that logs.
+    /// </summary>
+    public static void Main()
+    {
+        Logger logger = LogManager.GetCurrentClassLogger();
+        logger.Debug("Log message");
+        Console.Read();
+    }
 }
 ```
 
@@ -149,72 +148,69 @@ PM> Install-Package SumoLogic.Logging.Log4Net
   </configSections>
   <log4net debug="true">
     <appender name="SumoLogicAppender" type="SumoLogic.Logging.Log4Net.SumoLogicAppender, SumoLogic.Logging.Log4Net">
-	  <layout type="log4net.Layout.PatternLayout">
-	    <conversionPattern value="%date [%thread] %-5level %logger - %message%newline"/>
-	  </layout>
-	  <Url value="https://collectors.us2.sumologic.com/receiver/v1/http/your_endpoint_here==" />
-	  <ConnectionTimeout value="30000" /> <!-- in milliseconds -->
-	  <SourceName value="ExampleNameLog4NetAppender" />
-	  <SourceCategory value="ExampleCategoryLog4NetAppender" />
-	  <SourceHost value="ExampleHostLog4NetAppender" />
-	  <UseConsoleLog value="true" />
-    </appender>
-	<appender name="BufferedSumoLogicAppender" type="SumoLogic.Logging.Log4Net.BufferedSumoLogicAppender, SumoLogic.Logging.Log4Net">
-	  <layout type="log4net.Layout.PatternLayout">
-	    <conversionPattern value="%date [%thread] %-5level %logger - %message%newline"/>
+      <layout type="log4net.Layout.PatternLayout">
+        <conversionPattern value="%date [%thread] %-5level %logger - %message%newline"/>
       </layout>
-	  <Url value="https://collectors.us2.sumologic.com/receiver/v1/http/your_endpoint_here==" />
-	  <SourceName value="ExampleNameLog4NetBufferedAppender" />
-	  <SourceCategory value="ExampleCategoryLog4NetBufferedAppender" />
-	  <SourceHost value="ExampleHostLog4NetBufferedAppender" />
+      <Url value="https://collectors.us2.sumologic.com/receiver/v1/http/your_endpoint_here==" />
+      <ConnectionTimeout value="30000" /> <!-- in milliseconds -->
+      <SourceName value="ExampleNameLog4NetAppender" />
+      <SourceCategory value="ExampleCategoryLog4NetAppender" />
+      <SourceHost value="ExampleHostLog4NetAppender" />
+      <UseConsoleLog value="true" />
+    </appender>
+    <appender name="BufferedSumoLogicAppender" type="SumoLogic.Logging.Log4Net.BufferedSumoLogicAppender, SumoLogic.Logging.Log4Net">
+      <layout type="log4net.Layout.PatternLayout">
+        <conversionPattern value="%date [%thread] %-5level %logger - %message%newline"/>
+      </layout>
+      <Url value="https://collectors.us2.sumologic.com/receiver/v1/http/your_endpoint_here==" />
+      <SourceName value="ExampleNameLog4NetBufferedAppender" />
+      <SourceCategory value="ExampleCategoryLog4NetBufferedAppender" />
+      <SourceHost value="ExampleHostLog4NetBufferedAppender" />
       <ConnectionTimeout value="30000" />
       <RetryInterval value="5000" />
       <MessagesPerRequest value="10" />
       <MaxFlushInterval value="10000" />
       <FlushingAccuracy value="250" />
       <MaxQueueSizeBytes value="500000" />
-	  <UseConsoleLog value="true" />
-	</appender>
-	<root>
-	  <priority value="ALL"/>
-	  <level value="ALL"/>
-	  <appender-ref ref="SumoLogicAppender"/>
-	  <appender-ref ref="BufferedSumoLogicAppender"/>
-	</root>
-	<logger name="SumoLogic.Logging.Log4Net.Example.Program">
-	  <level value="ALL"/>
-	</logger>
+      <UseConsoleLog value="true" />
+    </appender>
+    <root>
+      <priority value="ALL"/>
+      <level value="ALL"/>
+      <appender-ref ref="SumoLogicAppender"/>
+      <appender-ref ref="BufferedSumoLogicAppender"/>
+    </root>
+    <logger name="SumoLogic.Logging.Log4Net.Example.Program">
+      <level value="ALL"/>
+    </logger>
   </log4net>
 
   <startup>
     <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.0"/>
   </startup>
-
 </configuration>
-
 ```
 
 ### Example Code
 ```csharp
 public static class Program
 {
-  /// <summary>
-  /// The log4net log.
-  /// </summary>
-  private static ILog log4netLog = LogManager.GetLogger(typeof(Program));
+    /// <summary>
+    /// The log4net log.
+    /// </summary>
+    private static ILog log4netLog = LogManager.GetLogger(typeof(Program));
 
-  /// <summary>
-  /// An example application that logs.
-  /// </summary>
-  public static void Main()
-  {
-    Console.WriteLine("Hello world!");
-    log4netLog.Info("Hello world!");
-    Console.ReadKey();
-  }
+    /// <summary>
+    /// An example application that logs.
+    /// </summary>
+    public static void Main()
+    {
+        Console.WriteLine("Hello world!");
+        log4netLog.Info("Hello world!");
+        Console.ReadKey();
+    }
 }
 ```
-
 
 # License
 [Apache 2.0](LICENSE)


### PR DESCRIPTION
README.md has a mix of tabs and spaces for the log4net xml configuration example. This causes XML elements to be unaligned when it's rendered on GitHub, making it hard to read. This PR normalizes all whitespace to spaces to remove the tabs.

It also indents all C# examples to 4 spaces for consistency. Some of them are only using 2 spaces.