### PR TITLE
target nlog 4.5.0-rc03 for netcore

### DIFF
--- a/SumoLogic.Logging.NLog/SumoLogic.Logging.NLog.csproj
+++ b/SumoLogic.Logging.NLog/SumoLogic.Logging.NLog.csproj
@@ -45,7 +45,7 @@
     <PackageReference Include="NLog" Version="4.3.3" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.5'">
-    <PackageReference Include="NLog" Version="5.0.0-beta09" />
+    <PackageReference Include="NLog" Version="4.5.0-rc03" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="System.Net.Http" Version="4.3.1" />


### PR DESCRIPTION
#60 /cc @latkin 

The NLog team has taken 5.x off their roadmap for the time being, and have added core support in 4.x-rc0x

https://twitter.com/NLogOfficial/status/943256082104901632

Lets target the appropriate NLog.