### PR TITLE
support asynchronous buffered message sends

### DIFF
--- a/SumoLogic.Logging.Common.Tests/Queue/BufferFlushingTaskTest.cs
+++ b/SumoLogic.Logging.Common.Tests/Queue/BufferFlushingTaskTest.cs
@@ -23,6 +23,9 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
+using System.Threading.Tasks;
+
 namespace SumoLogic.Logging.Common.Tests.Aggregation
 {
     using System;
@@ -42,21 +45,21 @@ namespace SumoLogic.Logging.Common.Tests.Aggregation
         /// </summary>
         [SuppressMessage("Microsoft.Performance", "CA1822:MarkMembersAsStatic", Justification = "Unit test")]
         [Fact]
-        public void FlushBySizeTest()
+        public async Task FlushBySizeTest()
         {
             var buffer = new BufferWithFifoEviction<string>(1000, new StringLengthCostAssigner());
             var bufferFlushingTask = new DummyBufferFlushingTask(buffer, TimeSpan.MaxValue, 3, "No-Name");
 
-            bufferFlushingTask.Run();
+            await bufferFlushingTask.Run();
             Assert.Equal(0, bufferFlushingTask.SentOut.Count);
 
             buffer.Add("msg1");
             buffer.Add("msg2");
-            bufferFlushingTask.Run();
+            await bufferFlushingTask.Run();
             Assert.Equal(0, bufferFlushingTask.SentOut.Count);
 
             buffer.Add("msg3");
-            bufferFlushingTask.Run();
+            await bufferFlushingTask.Run();
             Assert.Equal(1, bufferFlushingTask.SentOut.Count);
 
             Assert.Equal(3, bufferFlushingTask.SentOut[0].Count);
@@ -68,7 +71,7 @@ namespace SumoLogic.Logging.Common.Tests.Aggregation
         /// </summary>
         [SuppressMessage("Microsoft.Performance", "CA1822:MarkMembersAsStatic", Justification = "Unit test")]
         [Fact]
-        public void FlushWithNPlusOneElementsTest()
+        public async Task FlushWithNPlusOneElementsTest()
         {
             var buffer = new BufferWithFifoEviction<string>(1000, new StringLengthCostAssigner());
             var bufferFlushingTask = new DummyBufferFlushingTask(buffer, TimeSpan.MaxValue, 3, "No-Name");
@@ -77,7 +80,7 @@ namespace SumoLogic.Logging.Common.Tests.Aggregation
             buffer.Add("msg2");
             buffer.Add("msg3");
             buffer.Add("msg4");
-            bufferFlushingTask.Run();
+            await bufferFlushingTask.Run();
             Assert.Equal(4, bufferFlushingTask.SentOut[0].Count);
         }
 
@@ -86,7 +89,7 @@ namespace SumoLogic.Logging.Common.Tests.Aggregation
         /// </summary>
         [SuppressMessage("Microsoft.Performance", "CA1822:MarkMembersAsStatic", Justification = "Unit test")]
         [Fact]
-        public void FlushWhenBufferCapacityIsSmallTest()
+        public async Task FlushWhenBufferCapacityIsSmallTest()
         {
             var buffer = new BufferWithFifoEviction<string>(12, new StringLengthCostAssigner());
             var bufferFlushingTask = new DummyBufferFlushingTask(buffer, TimeSpan.MaxValue, 3, "No-Name");
@@ -94,7 +97,7 @@ namespace SumoLogic.Logging.Common.Tests.Aggregation
             buffer.Add("msg2");
             buffer.Add("msg3");
             buffer.Add("msg4");
-            bufferFlushingTask.Run();
+            await bufferFlushingTask.Run();
             Assert.Equal(3, bufferFlushingTask.SentOut[0].Count);
             Assert.Equal(new List<string>() { "msg2", "msg3", "msg4" }, bufferFlushingTask.SentOut[0]);
         }      

--- a/SumoLogic.Logging.Common.Tests/Sender/DummyBufferFlushigTask.cs
+++ b/SumoLogic.Logging.Common.Tests/Sender/DummyBufferFlushigTask.cs
@@ -23,6 +23,9 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
+using System.Threading.Tasks;
+
 namespace SumoLogic.Logging.Common.Tests.Aggregation
 {
     using System;
@@ -78,7 +81,7 @@ namespace SumoLogic.Logging.Common.Tests.Aggregation
         protected override IList<string> Aggregate(IList<string> messages)
         {
             return messages;
-        }
+        } 
 
         /// <summary>
         /// This sends out a message.
@@ -86,9 +89,9 @@ namespace SumoLogic.Logging.Common.Tests.Aggregation
         /// <param name="body">Message body.</param>
         /// <param name="name">Message name.</param>
         [Obsolete("use SendOut(IList<string> body, string name, string category, string host)")]
-        protected override void SendOut(IList<string> body, string name)
+        protected override Task SendOut(IList<string> body, string name)
         {
-            this.SentOut.Add(new List<string>(body));
+            return Task.Run(() => this.SentOut.Add(new List<string>(body)));
         }
 
         /// <summary>
@@ -98,9 +101,9 @@ namespace SumoLogic.Logging.Common.Tests.Aggregation
         /// <param name="name">Message name.</param>
         /// <param name="category">Message category.</param>
         /// <param name="host">Message host.</param>
-        protected override void SendOut(IList<string> body, string name, string category, string host)
+        protected override Task SendOut(IList<string> body, string name, string category, string host)
         {
-            this.SentOut.Add(new List<string>(body));
+            return Task.Run(() => this.SentOut.Add(new List<string>(body)));
         }
     }
 }

--- a/SumoLogic.Logging.Common.Tests/Sender/MockHttpMessageHandler.cs
+++ b/SumoLogic.Logging.Common.Tests/Sender/MockHttpMessageHandler.cs
@@ -145,7 +145,7 @@ namespace SumoLogic.Logging.Common.Sender
             if (request.Content != null)
             {
                 var requestContentStream = new MemoryStream();
-                request.Content.CopyToAsync(requestContentStream).Wait();
+                request.Content.CopyToAsync(requestContentStream).GetAwaiter().GetResult();
                 requestContentStream.Position = 0;
 
                 requestClone.Content = new StreamContent(requestContentStream);

--- a/SumoLogic.Logging.Common.Tests/Sender/SumoLogicMessageSenderTest.cs
+++ b/SumoLogic.Logging.Common.Tests/Sender/SumoLogicMessageSenderTest.cs
@@ -154,7 +154,7 @@ namespace SumoLogic.Logging.Common.Tests.Http
                 this.messagesHandler.CurrentResponse = new HttpResponseMessage(HttpStatusCode.OK);
             });
             this.sumoLogicMessageSender.Send("body", "name", "category", "host");
-            changeResponseTask.Wait();
+            changeResponseTask.GetAwaiter().GetResult();
             Assert.True(requestBeforeSuccess < this.messagesHandler.ReceivedRequests.Count);
             Assert.Equal(HttpStatusCode.OK, this.messagesHandler.CurrentResponse.StatusCode);
         }       

--- a/SumoLogic.Logging.Common/Sender/SumoLogicMessageSender.cs
+++ b/SumoLogic.Logging.Common/Sender/SumoLogicMessageSender.cs
@@ -149,14 +149,14 @@ namespace SumoLogic.Logging.Common.Sender
         /// <param name="category">The message category.</param>
         /// <param name="host">The message host.</param>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes")]
-        public void Send(string body, string name, string category, string host)
+        public async Task Send(string body, string name, string category, string host)
         {
             bool success = false;
             do
             {
                 try
                 {
-                    this.TrySend(body, name, category, host);
+                    await this.TrySend(body, name, category, host);
                     success = true;
                 }
                 catch (Exception ex)
@@ -195,9 +195,9 @@ namespace SumoLogic.Logging.Common.Sender
         /// <param name="body">The message body.</param>
         /// <param name="name">The message name.</param>
         [Obsolete("use Send(string body, string name, string category, string host)")]
-        public void Send(string body, string name)
+        public Task Send(string body, string name)
         {
-            Send(body, name, null, null);
+            return Send(body, name, null, null);
         }
 
         /// <summary>
@@ -207,7 +207,7 @@ namespace SumoLogic.Logging.Common.Sender
         /// <param name="name">The message name.</param>
         /// <param name="category">The message category.</param>
         /// <param name="host">The message host.</param>
-        public void TrySend(string body, string name, string category, string host)
+        public async Task TrySend(string body, string name, string category, string host)
         {
             if (this.Url == null)
             {
@@ -239,7 +239,7 @@ namespace SumoLogic.Logging.Common.Sender
                 }
                 try
                 {
-                    var response = this.HttpClient.PostAsync(this.Url, httpContent).Result;
+                    var response = await this.HttpClient.PostAsync(this.Url, httpContent);
                     if (!response.IsSuccessStatusCode)
                     {
                         if (this.Log.IsWarnEnabled)
@@ -295,9 +295,9 @@ namespace SumoLogic.Logging.Common.Sender
         /// <param name="body">The message body.</param>
         /// <param name="name">The message name.</param>
         [Obsolete("use TrySend(string body, string name, string category, string host)")]
-        public void TrySend(string body, string name)
+        public Task TrySend(string body, string name)
         {
-            TrySend(body, name, null, null);
+            return TrySend(body, name, null, null);
         }
 
         /// <summary>

--- a/SumoLogic.Logging.Common/Sender/SumoLogicMessageSenderBufferFlushingTask.cs
+++ b/SumoLogic.Logging.Common/Sender/SumoLogicMessageSenderBufferFlushingTask.cs
@@ -23,6 +23,9 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
+using System.Threading.Tasks;
+
 namespace SumoLogic.Logging.Common.Sender
 {
     using System;
@@ -131,9 +134,9 @@ namespace SumoLogic.Logging.Common.Sender
         /// <param name="body">Message body.</param>
         /// <param name="name">Message name.</param>
         [Obsolete("use SendOut(string body, string name, string category, string host)")]
-        protected override void SendOut(string body, String name)
+        protected override Task SendOut(string body, string name)
         {
-            SendOut(body, name, null, null);
+            return SendOut(body, name, null, null);
         }
 
         /// <summary>
@@ -143,7 +146,7 @@ namespace SumoLogic.Logging.Common.Sender
         /// <param name="name">Message name.</param>
         /// <param name="category">Message category.</param>
         /// <param name="host">Message host.</param>
-        protected override void SendOut(string body, string name, string category, string host)
+        protected override Task SendOut(string body, string name, string category, string host)
         {
             if (!this.MessageSender.CanSend)
             {
@@ -152,10 +155,10 @@ namespace SumoLogic.Logging.Common.Sender
                     Log.Error("HTTP Sender is not initialized");
                 }
                 
-                return;
+                return Task.FromResult(0);
             }
 
-            this.MessageSender.Send(body, name, category, host);
+           return this.MessageSender.Send(body, name, category, host);
         }
     }
 }

--- a/SumoLogic.Logging.Log4Net/BufferedSumoLogicAppender.cs
+++ b/SumoLogic.Logging.Log4Net/BufferedSumoLogicAppender.cs
@@ -271,7 +271,11 @@ namespace SumoLogic.Logging.Log4Net
                 this.SourceHost,
                 this.LogLog);
 
-            this.flushBufferTimer = new Timer((s) => flushBufferTask.Run(), null, TimeSpan.FromMilliseconds(0), TimeSpan.FromMilliseconds(this.FlushingAccuracy));
+            this.flushBufferTimer = new Timer(
+                async _ => await flushBufferTask.Run().ConfigureAwait(false),
+                null,
+                TimeSpan.FromMilliseconds(0),
+                TimeSpan.FromMilliseconds(this.FlushingAccuracy));
         }
 
         /// <summary>

--- a/SumoLogic.Logging.Log4Net/SumoLogicAppender.cs
+++ b/SumoLogic.Logging.Log4Net/SumoLogicAppender.cs
@@ -214,7 +214,10 @@ namespace SumoLogic.Logging.Log4Net
             }
 
             // this maintains synchronous behavior for single event scenarios.
-            this.SumoLogicMessageSender.TrySend(bodyBuilder.ToString(), this.SourceName, this.SourceCategory, this.SourceHost).Wait();
+            this.SumoLogicMessageSender
+                .TrySend(bodyBuilder.ToString(), this.SourceName, this.SourceCategory, this.SourceHost)
+                .GetAwaiter()
+                .GetResult();
         }
 
         /// <summary>

--- a/SumoLogic.Logging.Log4Net/SumoLogicAppender.cs
+++ b/SumoLogic.Logging.Log4Net/SumoLogicAppender.cs
@@ -23,6 +23,9 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
+using System.Threading.Tasks;
+
 namespace SumoLogic.Logging.Log4Net
 {
     using System;
@@ -210,7 +213,8 @@ namespace SumoLogic.Logging.Log4Net
                 }
             }
 
-            this.SumoLogicMessageSender.TrySend(bodyBuilder.ToString(), this.SourceName, this.SourceCategory, this.SourceHost);
+            // this maintains synchronous behavior for single event scenarios.
+            this.SumoLogicMessageSender.TrySend(bodyBuilder.ToString(), this.SourceName, this.SourceCategory, this.SourceHost).Wait();
         }
 
         /// <summary>

--- a/SumoLogic.Logging.NLog/BufferedSumoLogicTarget.cs
+++ b/SumoLogic.Logging.NLog/BufferedSumoLogicTarget.cs
@@ -294,7 +294,7 @@ namespace SumoLogic.Logging.NLog
             if (this.flushBufferTask != null)
             {
                 // this is NOT present in the log4net code. one-time blocking operation.
-                this.flushBufferTask.FlushAndSend().Wait();
+                this.flushBufferTask.FlushAndSend().GetAwaiter().GetResult();
             }
 
             this.flushBufferTask = new SumoLogicMessageSenderBufferFlushingTask(
@@ -385,7 +385,7 @@ namespace SumoLogic.Logging.NLog
                 if (task != null)
                 {
                     // i don't love this, but it maintains parity w/ existing sync calls
-                    task.FlushAndSend().Wait();
+                    task.FlushAndSend().GetAwaiter().GetResult();
                 }
 
                 asyncContinuation(null);

--- a/SumoLogic.Logging.NLog/SumoLogicTarget.cs
+++ b/SumoLogic.Logging.NLog/SumoLogicTarget.cs
@@ -230,7 +230,10 @@ namespace SumoLogic.Logging.NLog
             }
 
             // synchronous send
-            this.SumoLogicMessageSender.TrySend(body, sourceName, sourceCategory, sourceHost).Wait();
+            this.SumoLogicMessageSender
+                .TrySend(body, sourceName, sourceCategory, sourceHost)
+                .GetAwaiter()
+                .GetResult();
         }
 
         /// <summary>

--- a/SumoLogic.Logging.NLog/SumoLogicTarget.cs
+++ b/SumoLogic.Logging.NLog/SumoLogicTarget.cs
@@ -229,7 +229,8 @@ namespace SumoLogic.Logging.NLog
                 body = string.Concat(body, Environment.NewLine);
             }
 
-            this.SumoLogicMessageSender.TrySend(body, sourceName, sourceCategory, sourceHost);
+            // synchronous send
+            this.SumoLogicMessageSender.TrySend(body, sourceName, sourceCategory, sourceHost).Wait();
         }
 
         /// <summary>

--- a/SumoLogic.Logging.Serilog/BufferedSumoLogicSink.cs
+++ b/SumoLogic.Logging.Serilog/BufferedSumoLogicSink.cs
@@ -119,7 +119,7 @@ namespace SumoLogic.Logging.Serilog
                 this.logService);
 
             this.flushBufferTimer = new Timer(
-                _ => flushBufferTask.Run(),
+                async _ => await flushBufferTask.Run(),
                 null,
                 TimeSpan.FromMilliseconds(0),
                 connection.FlushingAccuracy);

--- a/SumoLogic.Logging.Serilog/SumoLogicSink.cs
+++ b/SumoLogic.Logging.Serilog/SumoLogicSink.cs
@@ -111,10 +111,11 @@ namespace SumoLogic.Logging.Serilog
             }
 
             this.messageSender.TrySend(
-                this.formatter.Format(logEvent),
-                this.source.SourceName,
-                this.source.SourceCategory,
-                this.source.SourceHost);
+                    this.formatter.Format(logEvent),
+                    this.source.SourceName,
+                    this.source.SourceCategory,
+                    this.source.SourceHost)
+                .Wait();
         }
 
         /// <inheritdoc/>

--- a/SumoLogic.Logging.Serilog/SumoLogicSink.cs
+++ b/SumoLogic.Logging.Serilog/SumoLogicSink.cs
@@ -115,7 +115,8 @@ namespace SumoLogic.Logging.Serilog
                     this.source.SourceName,
                     this.source.SourceCategory,
                     this.source.SourceHost)
-                .Wait();
+                .GetAwaiter()
+                .GetResult();
         }
 
         /// <inheritdoc/>


### PR DESCRIPTION
This PR adds support for asynchronous buffered message sending. 
 
In production services, we are regularly experiencing threadpool exhaustion due to queued `BufferedFlushingTask`s blocked on CLR worker threads. When sending apx 5-10k messages per minute, we produced a backlog of 2044 blocked threads on a Threadpool instance w/ a max of 2047. That's due to `SumoLogicMessageSender.TrySend` invoking `PostAsync` with a blocking `Result` call, which can cause threadpool exhaustion when using the buffered sender under heavy load. This change removes the blocking `Result` and surfaces the async Task to the `Timer`, resulting in far reduced CLR worker thread-pool usage and slightly increased IOCP thread usage (10 and 20 respectively under the same load, averaged samples).

Since there's no task execution order guaranteed, the unbuffered sender is left synchronous to prevent out-of-order message arrival. While the buffered sender also suffers from non-deterministic task ordering, it's no worse than the current threadpool dispatch model, and only a risk for very small `FlushingAccuracy` values. So don't do that.

This code is running in production environments processing 5-15k messages per minute per endpoint *using the log4net appender*. No real-world testing was performed for either the NLog or SeriLog implementations. The NLog `FlushAsync` method needs to be reviewed by someone more familiar w/ NLog's async continuation mechanism.