### PR TITLE
NLog SumoLogicTarget include formatted message in default layout

### DIFF
--- a/SumoLogic.Logging.NLog/BufferedSumoLogicTarget.cs
+++ b/SumoLogic.Logging.NLog/BufferedSumoLogicTarget.cs
@@ -73,6 +73,7 @@ namespace SumoLogic.Logging.NLog
         public BufferedSumoLogicTarget(ILog log, HttpMessageHandler httpMessageHandler)
         {
             this.SourceName = "Nlog-SumoObject-Buffered";
+            this.OptimizeBufferReuse = true;
             this.ConnectionTimeout = 60000;
             this.RetryInterval = 10000;
             this.MessagesPerRequest = 100;
@@ -81,7 +82,7 @@ namespace SumoLogic.Logging.NLog
             this.MaxQueueSizeBytes = 1000000;
             this.LogLog = new InternalLoggerLog(GetType().Name + ": ", log);
             this.HttpMessageHandler = httpMessageHandler;
-            this.Layout = "${longdate}|${level:uppercase=true}|${logger}${exception:format=tostring}${newline}";
+            this.Layout = "${longdate}|${level:uppercase=true}|${logger}|${message}${exception:format=tostring}${newline}";
         }
 
         /// <summary>
@@ -335,7 +336,7 @@ namespace SumoLogic.Logging.NLog
                 return;
             }
 
-            var body = this.Layout?.Render(logEvent) ?? string.Empty;
+            var body = this.RenderLogEvent(this.Layout, logEvent) ?? string.Empty;
             if (body.Length < Environment.NewLine.Length || body[body.Length - 1] != Environment.NewLine[Environment.NewLine.Length - 1])
             {
                 body = string.Concat(body, Environment.NewLine);

--- a/SumoLogic.Logging.NLog/SumoLogicTarget.cs
+++ b/SumoLogic.Logging.NLog/SumoLogicTarget.cs
@@ -56,10 +56,11 @@ namespace SumoLogic.Logging.NLog
         public SumoLogicTarget(ILog log, HttpMessageHandler httpMessageHandler)
         {
             this.SourceName = "Nlog-SumoObject";
+            this.OptimizeBufferReuse = true;
             this.ConnectionTimeout = 60000;
             this.LogLog = new InternalLoggerLog(GetType().Name + ": ", log);
             this.HttpMessageHandler = httpMessageHandler;
-            this.Layout = "${longdate}|${level:uppercase=true}|${logger}${exception:format=tostring}${newline}";
+            this.Layout = "${longdate}|${level:uppercase=true}|${logger}|${message}${exception:format=tostring}${newline}";
         }
 
         /// <summary>
@@ -223,7 +224,7 @@ namespace SumoLogic.Logging.NLog
             var sourceName = _sourceLayout?.Render(logEvent) ?? string.Empty;
             var sourceCategory = _categoryLayout?.Render(logEvent) ?? string.Empty;
             var sourceHost = _hostLayout?.Render(logEvent) ?? string.Empty;
-            var body = this.Layout?.Render(logEvent) ?? string.Empty;
+            var body = this.RenderLogEvent(this.Layout, logEvent) ?? string.Empty;
             if (body.Length < Environment.NewLine.Length || body[body.Length - 1] != Environment.NewLine[Environment.NewLine.Length - 1])
             {
                 body = string.Concat(body, Environment.NewLine);


### PR DESCRIPTION
Reverting change introduced with  #69 

Original default Layout:

> ${longdate}|${level:uppercase=true}|${logger}|${message}

Changed default layout:

> ${longdate}|${level:uppercase=true}|${logger}${exception:format=tostring}${newline}

New fixed default layout (Includes `${message}` again):

> ${longdate}|${level:uppercase=true}|${logger}${message}${exception:format=tostring}${newline}