### PR TITLE
Removed async and await from flushBufferTimer to avoid unhandled exceptions

### DIFF
--- a/SumoLogic.Logging.Common.Tests/Sender/SumoLogicMessageSenderTest.cs
+++ b/SumoLogic.Logging.Common.Tests/Sender/SumoLogicMessageSenderTest.cs
@@ -69,7 +69,7 @@ namespace SumoLogic.Logging.Common.Tests.Http
         public void HttpClientCallWith200ResponseTest()
         {
             Assert.Equal(0, messagesHandler.ReceivedRequests.Count);
-            sumoLogicMessageSender.Send("body", "name", "category", "host");
+            sumoLogicMessageSender.Send("body", "name", "category", "host").Wait();
             Assert.Equal(1, messagesHandler.ReceivedRequests.Count);
         }      
 
@@ -80,7 +80,7 @@ namespace SumoLogic.Logging.Common.Tests.Http
         [Fact]
         public void RequestHeaderTest()
         {
-           sumoLogicMessageSender.Send("body", "name", "category", "host");
+            sumoLogicMessageSender.Send("body", "name", "category", "host").Wait();
             Assert.Equal("name", messagesHandler.LastReceivedRequest.Content.Headers.GetValues("X-Sumo-Name").First<string>());
             Assert.Equal("category", messagesHandler.LastReceivedRequest.Content.Headers.GetValues("X-Sumo-Category").First<string>());
             Assert.Equal("host", messagesHandler.LastReceivedRequest.Content.Headers.GetValues("X-Sumo-Host").First<string>());
@@ -95,7 +95,7 @@ namespace SumoLogic.Logging.Common.Tests.Http
         public void RequestContentTest()
         {
             string body = "ContentBody";
-            sumoLogicMessageSender.Send(body, "name", "category", "host");
+            sumoLogicMessageSender.Send(body, "name", "category", "host").Wait();
             var contentInString = messagesHandler.LastReceivedRequest.Content.ReadAsStringAsync().Result;
             Assert.Equal(body, contentInString);
         }
@@ -118,7 +118,7 @@ namespace SumoLogic.Logging.Common.Tests.Http
         {
             Assert.True(sumoLogicMessageSender.CanSend);
             Assert.True(sumoLogicMessageSender.CanTrySend);
-            sumoLogicMessageSender.Send("body", "name", "category", "host");
+            sumoLogicMessageSender.Send("body", "name", "category", "host").Wait();
             Assert.Equal(HttpStatusCode.OK, messagesHandler.CurrentResponse.StatusCode);
         }
 
@@ -132,7 +132,7 @@ namespace SumoLogic.Logging.Common.Tests.Http
             sumoLogicMessageSender.Url = null;
             Assert.False(sumoLogicMessageSender.CanSend);
             Assert.False(sumoLogicMessageSender.CanTrySend);
-            sumoLogicMessageSender.Send("body", "name", "category", "host");
+            sumoLogicMessageSender.Send("body", "name", "category", "host").Wait();
             Assert.Equal(0, messagesHandler.ReceivedRequests.Count);          
         }
 
@@ -153,7 +153,7 @@ namespace SumoLogic.Logging.Common.Tests.Http
                 requestBeforeSuccess = messagesHandler.ReceivedRequests.Count;
                 messagesHandler.CurrentResponse = new HttpResponseMessage(HttpStatusCode.OK);
             });
-            sumoLogicMessageSender.Send("body", "name", "category", "host");
+            sumoLogicMessageSender.Send("body", "name", "category", "host").Wait();
             changeResponseTask.GetAwaiter().GetResult();
             Assert.True(requestBeforeSuccess < messagesHandler.ReceivedRequests.Count);
             Assert.Equal(HttpStatusCode.OK, messagesHandler.CurrentResponse.StatusCode);

--- a/SumoLogic.Logging.Common/Sender/BufferFlushingTask.cs
+++ b/SumoLogic.Logging.Common/Sender/BufferFlushingTask.cs
@@ -30,7 +30,6 @@ namespace SumoLogic.Logging.Common.Sender
     using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
     using System.Globalization;
-    using System.Linq;
     using System.Threading.Tasks;
     using SumoLogic.Logging.Common.Log;
     using SumoLogic.Logging.Common.Queue;
@@ -118,11 +117,6 @@ namespace SumoLogic.Logging.Common.Sender
                 }
 
                 this.IsFlushing = false;
-            }
-            catch (AggregateException ex)
-            {
-                var firstException = ex.Flatten().InnerExceptions?.FirstOrDefault() ?? ex.InnerException ?? ex;
-                Log.Warn($"HTTP Sender flush failed: {firstException.GetType()}: {firstException.Message}");
             }
             catch (Exception ex)
             {

--- a/SumoLogic.Logging.Common/Sender/SumoLogicMessageSender.cs
+++ b/SumoLogic.Logging.Common/Sender/SumoLogicMessageSender.cs
@@ -256,18 +256,6 @@ namespace SumoLogic.Logging.Common.Sender
                         this.Log.Debug("Successfully sent log request to Sumo Logic");
                     }
                 }
-                catch (OperationCanceledException ex)
-                {
-                    if (this.Log.IsWarnEnabled)
-                    {
-                        this.Log.Warn("Could not send log to Sumo Logic. Operation was canceled");
-                    }
-                    else if (this.Log.IsDebugEnabled)
-                    {
-                        this.Log.Debug($"Could not send log to Sumo Logic. {ex.GetType()}: {ex.Message}");
-                    }
-                    // No rethrow, the operation cannot be retried
-                }
                 catch (ObjectDisposedException ex)
                 {
                     if (this.Log.IsWarnEnabled)

--- a/SumoLogic.Logging.Common/Sender/SumoLogicMessageSender.cs
+++ b/SumoLogic.Logging.Common/Sender/SumoLogicMessageSender.cs
@@ -27,7 +27,6 @@ namespace SumoLogic.Logging.Common.Sender
 {
     using System;
     using System.IO;
-    using System.Linq;
     using System.Net;
     using System.Net.Http;
     using System.Text;
@@ -256,23 +255,6 @@ namespace SumoLogic.Logging.Common.Sender
                     {
                         this.Log.Debug("Successfully sent log request to Sumo Logic");
                     }
-                }
-                catch (AggregateException ex)
-                {
-                    var firstException = ex.Flatten().InnerExceptions?.FirstOrDefault() ?? ex.InnerException ?? ex;
-                    if (this.Log.IsWarnEnabled)
-                    {
-                        this.Log.Warn($"Could not send log to Sumo Logic. {firstException.GetType()}:{firstException.Message}");
-                    }
-                    else if (this.Log.IsDebugEnabled)
-                    {
-                        this.Log.Debug($"Could not send log to Sumo Logic. {firstException.GetType()}:{firstException.Message}");
-                    }
-
-                    if (firstException is OperationCanceledException || firstException is ObjectDisposedException)
-                        return; // No rethrow, the operation cannot be retried
-
-                    throw firstException;
                 }
                 catch (OperationCanceledException ex)
                 {

--- a/SumoLogic.Logging.Common/Sender/SumoLogicMessageSender.cs
+++ b/SumoLogic.Logging.Common/Sender/SumoLogicMessageSender.cs
@@ -27,6 +27,7 @@ namespace SumoLogic.Logging.Common.Sender
 {
     using System;
     using System.IO;
+    using System.Linq;
     using System.Net;
     using System.Net.Http;
     using System.Text;
@@ -156,7 +157,7 @@ namespace SumoLogic.Logging.Common.Sender
             {
                 try
                 {
-                    await this.TrySend(body, name, category, host);
+                    await this.TrySend(body, name, category, host).ConfigureAwait(false);
                     success = true;
                 }
                 catch (Exception ex)
@@ -168,22 +169,10 @@ namespace SumoLogic.Logging.Common.Sender
 
                     if (this.Log.IsErrorEnabled)
                     {
-                        this.Log.Error("Error trying send messages. Exception: " + ex.Message);
+                        this.Log.Error($"Error trying send messages. {ex.GetType()}: {ex.Message}");
                     }
 
-                    try
-                    {
-                        Task.Delay(this.RetryInterval).GetAwaiter().GetResult();
-                    }
-                    catch (Exception ex2)
-                    {
-                        if (this.Log.IsErrorEnabled)
-                        {
-                            this.Log.Error(ex2.Message);
-                        }
-
-                        break;
-                    }
+                    await Task.Delay(this.RetryInterval).ConfigureAwait(false);
                 }
             }
             while (!success);
@@ -215,7 +204,6 @@ namespace SumoLogic.Logging.Common.Sender
                 {
                     this.Log.Warn("Could not send log to Sumo Logic (null Url)");
                 }
-
                 return;
             }
 
@@ -240,7 +228,17 @@ namespace SumoLogic.Logging.Common.Sender
 
                 try
                 {
-                    var response = await this.HttpClient.PostAsync(this.Url, httpContent);
+                    var httpClient = this.HttpClient;
+                    if (httpClient == null)
+                    {
+                        if (this.Log.IsWarnEnabled)
+                        {
+                            this.Log.Warn("Could not send log to Sumo Logic. HttpClient has been disposed");
+                        }
+                        return;
+                    }
+
+                    var response = await httpClient.PostAsync(this.Url, httpContent).ConfigureAwait(false);
                     if (!response.IsSuccessStatusCode)
                     {
                         if (this.Log.IsWarnEnabled)
@@ -261,48 +259,56 @@ namespace SumoLogic.Logging.Common.Sender
                 }
                 catch (AggregateException ex)
                 {
+                    var firstException = ex.Flatten().InnerExceptions?.FirstOrDefault() ?? ex.InnerException ?? ex;
                     if (this.Log.IsWarnEnabled)
                     {
-                        this.Log.Warn("Could not send log to Sumo Logic");
+                        this.Log.Warn($"Could not send log to Sumo Logic. {firstException.GetType()}:{firstException.Message}");
                     }
-
-                    if (this.Log.IsDebugEnabled)
+                    else if (this.Log.IsDebugEnabled)
                     {
-                        this.Log.Debug("Reason: " + ex.InnerException.Message);
+                        this.Log.Debug($"Could not send log to Sumo Logic. {firstException.GetType()}:{firstException.Message}");
                     }
 
-                    throw ex.InnerException;
+                    if (firstException is OperationCanceledException || firstException is ObjectDisposedException)
+                        return; // No rethrow, the operation cannot be retried
+
+                    throw firstException;
                 }
-                catch (IOException ex)
+                catch (OperationCanceledException ex)
                 {
                     if (this.Log.IsWarnEnabled)
                     {
-                        this.Log.Warn("Could not send log to Sumo Logic");
+                        this.Log.Warn("Could not send log to Sumo Logic. Operation was canceled");
                     }
-
-                    if (this.Log.IsDebugEnabled)
+                    else if (this.Log.IsDebugEnabled)
                     {
-                        this.Log.Debug("Reason: " + ex.Message);
+                        this.Log.Debug($"Could not send log to Sumo Logic. {ex.GetType()}: {ex.Message}");
                     }
-
+                    // No rethrow, the operation cannot be retried
+                }
+                catch (ObjectDisposedException ex)
+                {
+                    if (this.Log.IsWarnEnabled)
+                    {
+                        this.Log.Warn("Could not send log to Sumo Logic. Operation was disposed");
+                    }
+                    else if (this.Log.IsDebugEnabled)
+                    {
+                        this.Log.Debug($"Could not send log to Sumo Logic. {ex.GetType()}: {ex.Message}");
+                    }
+                    // No rethrow, the operation cannot be retried
+                }
+                catch (Exception ex)
+                {
+                    if (this.Log.IsWarnEnabled)
+                    {
+                        this.Log.Warn($"Could not send log to Sumo Logic. {ex.GetType()}: {ex.Message}");
+                    }
+                    else if (this.Log.IsDebugEnabled)
+                    {
+                        this.Log.Debug($"Could not send log to Sumo Logic. {ex.GetType()}: {ex.Message}");
+                    }
                     throw;
-                }
-                // Its possible for a buffered sender to get disposed while an outstanding timer callback is
-                // executing. netstandard 1.3's System.Threading.Timer task doesn't implement the overload of
-                // Dispose that has a WaitHandle, so we'll just have to suppress these exceptions.
-                catch (TaskCanceledException)
-                {
-                    if (this.Log.IsWarnEnabled)
-                    {
-                        this.Log.Warn("Could not send log to Sumo Logic; a task was canceled");
-                    }
-                }
-                catch (ObjectDisposedException ode)
-                {
-                    if (this.Log.IsWarnEnabled)
-                    {
-                        this.Log.Warn($"Could not send log to Sumo Logic: ${ode.Message}");
-                    }
                 }
             }
         }

--- a/SumoLogic.Logging.Log4Net/BufferedSumoLogicAppender.cs
+++ b/SumoLogic.Logging.Log4Net/BufferedSumoLogicAppender.cs
@@ -272,7 +272,7 @@ namespace SumoLogic.Logging.Log4Net
                 this.LogLog);
 
             this.flushBufferTimer = new Timer(
-                async _ => await flushBufferTask.Run().ConfigureAwait(false),
+                _ => flushBufferTask.Run(), // No task await to avoid unhandled exception
                 null,
                 TimeSpan.FromMilliseconds(0),
                 TimeSpan.FromMilliseconds(this.FlushingAccuracy));
@@ -325,16 +325,16 @@ namespace SumoLogic.Logging.Log4Net
         {
             base.OnClose();
 
-            if (this.SumoLogicMessageSender != null)
-            {
-                this.SumoLogicMessageSender.Dispose();
-                this.SumoLogicMessageSender = null;
-            }
-
             if (this.flushBufferTimer != null)
             {
                 this.flushBufferTimer.Dispose();
                 this.flushBufferTimer = null;
+            }
+
+            if (this.SumoLogicMessageSender != null)
+            {
+                this.SumoLogicMessageSender.Dispose();
+                this.SumoLogicMessageSender = null;
             }
         }
 

--- a/SumoLogic.Logging.Serilog/SumoLogicSink.cs
+++ b/SumoLogic.Logging.Serilog/SumoLogicSink.cs
@@ -119,7 +119,9 @@ namespace SumoLogic.Logging.Serilog
                 .GetResult();
         }
 
-        /// <inheritdoc/>
+        /// <summary>
+        /// Dispose for Serilog CloseAndFlush
+        /// </summary>
         public void Dispose() => this.messageSender?.Dispose();
     }
 }


### PR DESCRIPTION
Resolves #88 and resolves #83 (Bug introduced in ver. 1.0.0.11)

Timer-threads will no longer await any task exceptions, and avoid any unhandled exceptions the task might produce.

Now catches the base-class `OperationCanceledException` instead of the specialized `TaskCanceledException`

Now also checks if HttpClient has been Disposed and assigned to `null`, before using it. Avoiding possible `NullReferenceException` on shutdown.

Now correctly assigns `IsFlushing = false` and `LastFlushedOn = DateTime.UtcNow` on completing flush (Avoid rapid-flushing every 250 ms, and instead write larger batches).

Now performs flush in Serilog Buffered Sink on Dispose (CloseAndFlush)

Fixed all `await`-logic to use `ConfigureAwait(false)` to to avoid deadlock when blocking for async-operation-result. See  #91