### PR TITLE
Bumping to allow Serilog 4.*

### DIFF
--- a/SumoLogic.Logging.Serilog/SumoLogic.Logging.Serilog.csproj
+++ b/SumoLogic.Logging.Serilog/SumoLogic.Logging.Serilog.csproj
@@ -26,7 +26,7 @@
         <ProjectReference Include="..\SumoLogic.Logging.Common\SumoLogic.Logging.Common.csproj" />
     </ItemGroup>
 	<ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-            <PackageReference Include="Serilog" Version="[2.0,4.0)" />
+            <PackageReference Include="Serilog" Version="[2.0,5.0)" />
 	</ItemGroup>
 	<ItemGroup Condition=" '$(TargetFramework)' == 'net45' Or  '$(TargetFramework)' == 'netstandard1.3'">
 	    <PackageReference Include="Serilog" Version="[2.0,3.0)" />

--- a/SumoLogic.Logging.Serilog/SumoLogic.Logging.Serilog.csproj
+++ b/SumoLogic.Logging.Serilog/SumoLogic.Logging.Serilog.csproj
@@ -26,7 +26,7 @@
         <ProjectReference Include="..\SumoLogic.Logging.Common\SumoLogic.Logging.Common.csproj" />
     </ItemGroup>
 	<ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-            <PackageReference Include="Serilog" Version="[2.0,5.0)" />
+            <PackageReference Include="Serilog" Version="[2.0,)" />
 	</ItemGroup>
 	<ItemGroup Condition=" '$(TargetFramework)' == 'net45' Or  '$(TargetFramework)' == 'netstandard1.3'">
 	    <PackageReference Include="Serilog" Version="[2.0,3.0)" />


### PR DESCRIPTION
Serilog 4.* released without any major breaking changes, this is needed to allow for Serilog sinks to take advantage of the new batching sinks that are native and not in a separate package anymore.