### PR TITLE
fix: Allow Serilog 4.x for .net framework 4.5 to remove dependency warnings

### DIFF
--- a/SumoLogic.Logging.Serilog/SumoLogic.Logging.Serilog.csproj
+++ b/SumoLogic.Logging.Serilog/SumoLogic.Logging.Serilog.csproj
@@ -29,6 +29,6 @@
             <PackageReference Include="Serilog" Version="[2.0,)" />
 	</ItemGroup>
 	<ItemGroup Condition=" '$(TargetFramework)' == 'net45' Or  '$(TargetFramework)' == 'netstandard1.3'">
-	    <PackageReference Include="Serilog" Version="[2.0,3.0)" />
+	    <PackageReference Include="Serilog" Version="[2.0,)" />
 	</ItemGroup>
 </Project>


### PR DESCRIPTION
Allow Serilog 4.x for .net framwork 4.5 to remove dependency warning

Serilog 4.3.0 supports:
- .NET 6.0 (and higher)
- .NET Standard 2.0 (and higher)
- .NET Framework 4.6.2 (and higher)
