### PR TITLE
feat: Added .NET Framework 4.8 support - All logging libraries now target net45, net48, and netstandard2.0

### DIFF
--- a/SumoLogic.Logging.AspNetCore.Example/Startup.cs
+++ b/SumoLogic.Logging.AspNetCore.Example/Startup.cs
@@ -26,6 +26,7 @@
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
 namespace SumoLogic.Logging.AspNetCore.Example
@@ -36,31 +37,42 @@ namespace SumoLogic.Logging.AspNetCore.Example
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
-            services.AddMvc();
+            services.AddControllers();
+            services.AddLogging(builder =>
+            {
+                builder.AddConsole();
+                builder.AddSumoLogic("https://collectors.us2.sumologic.com/receiver/v1/http/your_endpoint_here==");
+            });
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
 #if !USE_BUILDER
-        public void Configure(IApplicationBuilder app, IHostingEnvironment env, ILoggerFactory loggerFactory)
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
         {
-            loggerFactory.AddConsole();
-            loggerFactory.AddSumoLogic("https://collectors.us2.sumologic.com/receiver/v1/http/your_endpoint_here==");
             if (env.IsDevelopment())
             {
                 app.UseDeveloperExceptionPage();
             }
 
-            app.UseMvc();
+            app.UseRouting();
+            app.UseEndpoints(endpoints =>
+            {
+                endpoints.MapControllers();
+            });
         }
 #else
-        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
         {
             if (env.IsDevelopment())
             {
                 app.UseDeveloperExceptionPage();
             }
 
-            app.UseMvc();
+            app.UseRouting();
+            app.UseEndpoints(endpoints =>
+            {
+                endpoints.MapControllers();
+            });
         }
 #endif
     }

--- a/SumoLogic.Logging.AspNetCore.Example/SumoLogic.Logging.AspNetCore.Example.csproj
+++ b/SumoLogic.Logging.AspNetCore.Example/SumoLogic.Logging.AspNetCore.Example.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
     </PropertyGroup>
     <ItemGroup>
         <Folder Include="wwwroot\" />

--- a/SumoLogic.Logging.AspNetCore.Example/SumoLogic.Logging.AspNetCore.Example.csproj
+++ b/SumoLogic.Logging.AspNetCore.Example/SumoLogic.Logging.AspNetCore.Example.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
     </PropertyGroup>
     <ItemGroup>
         <Folder Include="wwwroot\" />

--- a/SumoLogic.Logging.AspNetCore.Example/SumoLogic.Logging.AspNetCore.Example.csproj
+++ b/SumoLogic.Logging.AspNetCore.Example/SumoLogic.Logging.AspNetCore.Example.csproj
@@ -1,11 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
     <PropertyGroup>
-        <TargetFramework>netcoreapp2.1</TargetFramework>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
     </PropertyGroup>
     <ItemGroup>
         <Folder Include="wwwroot\" />
-        <PackageReference Include="Microsoft.AspNetCore.All" />
-        <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="2.0.4" />
         <ProjectReference Include="..\SumoLogic.Logging.AspNetCore\SumoLogic.Logging.AspNetCore.csproj" />
     </ItemGroup>
 </Project>

--- a/SumoLogic.Logging.AspNetCore.Tests/SumoLogic.Logging.AspNetCore.Tests.csproj
+++ b/SumoLogic.Logging.AspNetCore.Tests/SumoLogic.Logging.AspNetCore.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
     <ItemGroup>

--- a/SumoLogic.Logging.AspNetCore.Tests/SumoLogic.Logging.AspNetCore.Tests.csproj
+++ b/SumoLogic.Logging.AspNetCore.Tests/SumoLogic.Logging.AspNetCore.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>netcoreapp2.1</TargetFramework>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
     <ItemGroup>

--- a/SumoLogic.Logging.AspNetCore.Tests/SumoLogic.Logging.AspNetCore.Tests.csproj
+++ b/SumoLogic.Logging.AspNetCore.Tests/SumoLogic.Logging.AspNetCore.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
     <ItemGroup>

--- a/SumoLogic.Logging.Common.Tests/SumoLogic.Logging.Common.Tests.csproj
+++ b/SumoLogic.Logging.Common.Tests/SumoLogic.Logging.Common.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>netcoreapp2.1</TargetFramework>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="xunit" Version="2.4.1" />

--- a/SumoLogic.Logging.Common.Tests/SumoLogic.Logging.Common.Tests.csproj
+++ b/SumoLogic.Logging.Common.Tests/SumoLogic.Logging.Common.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="xunit" Version="2.4.1" />

--- a/SumoLogic.Logging.Common.Tests/SumoLogic.Logging.Common.Tests.csproj
+++ b/SumoLogic.Logging.Common.Tests/SumoLogic.Logging.Common.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="xunit" Version="2.4.1" />

--- a/SumoLogic.Logging.Common/SumoLogic.Logging.Common.csproj
+++ b/SumoLogic.Logging.Common/SumoLogic.Logging.Common.csproj
@@ -4,7 +4,7 @@
         <Description>Shared library used by .NET log appenders uploading to Sumo Logic.</Description>
         <Authors>Sumo Logic</Authors>
         <Copyright>Copyright © 2018 Sumo Logic Inc. - All Rights Reserved</Copyright>
-        <TargetFrameworks>netstandard2.0;net45</TargetFrameworks>
+        <TargetFrameworks>netstandard2.0;net45;net48</TargetFrameworks>
         <SignAssembly Condition="'$(Configuration)' == 'Release' ">true</SignAssembly>
         <AssemblyOriginatorKeyFile>..\SumoLogic.Logging.snk</AssemblyOriginatorKeyFile>
         <PackageProjectUrl>https://github.com/SumoLogic/sumologic-net-appenders</PackageProjectUrl>

--- a/SumoLogic.Logging.Common/SumoLogic.Logging.Common.csproj
+++ b/SumoLogic.Logging.Common/SumoLogic.Logging.Common.csproj
@@ -4,10 +4,9 @@
         <Description>Shared library used by .NET log appenders uploading to Sumo Logic.</Description>
         <Authors>Sumo Logic</Authors>
         <Copyright>Copyright © 2018 Sumo Logic Inc. - All Rights Reserved</Copyright>
-        <TargetFrameworks>netstandard2.0;netstandard1.3;net45</TargetFrameworks>
+        <TargetFrameworks>netstandard2.0;net45</TargetFrameworks>
         <SignAssembly Condition="'$(Configuration)' == 'Release' ">true</SignAssembly>
         <AssemblyOriginatorKeyFile>..\SumoLogic.Logging.snk</AssemblyOriginatorKeyFile>
-        <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.3' ">1.6.1</NetStandardImplicitPackageVersion>
         <PackageProjectUrl>https://github.com/SumoLogic/sumologic-net-appenders</PackageProjectUrl>
         <PackageIconUrl>https://raw.githubusercontent.com/SumoLogic/sumologic-net-appenders/master/icon.png</PackageIconUrl>
         <RepositoryUrl>https://github.com/SumoLogic/sumologic-net-appenders</RepositoryUrl>

--- a/SumoLogic.Logging.Log4Net.Example/SumoLogic.Logging.Log4Net.Example.csproj
+++ b/SumoLogic.Logging.Log4Net.Example/SumoLogic.Logging.Log4Net.Example.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
     </PropertyGroup>
     <ItemGroup>
         <CodeAnalysisDictionary Include="..\CustomDictionary.xml">

--- a/SumoLogic.Logging.Log4Net.Example/SumoLogic.Logging.Log4Net.Example.csproj
+++ b/SumoLogic.Logging.Log4Net.Example/SumoLogic.Logging.Log4Net.Example.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
     </PropertyGroup>
     <ItemGroup>
         <CodeAnalysisDictionary Include="..\CustomDictionary.xml">

--- a/SumoLogic.Logging.Log4Net.Example/SumoLogic.Logging.Log4Net.Example.csproj
+++ b/SumoLogic.Logging.Log4Net.Example/SumoLogic.Logging.Log4Net.Example.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp2.1</TargetFramework>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
     </PropertyGroup>
     <ItemGroup>
         <CodeAnalysisDictionary Include="..\CustomDictionary.xml">

--- a/SumoLogic.Logging.Log4Net.Tests/SumoLogic.Logging.Log4Net.Tests.csproj
+++ b/SumoLogic.Logging.Log4Net.Tests/SumoLogic.Logging.Log4Net.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>netcoreapp2.1</TargetFramework>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="xunit" Version="2.4.1" />

--- a/SumoLogic.Logging.Log4Net.Tests/SumoLogic.Logging.Log4Net.Tests.csproj
+++ b/SumoLogic.Logging.Log4Net.Tests/SumoLogic.Logging.Log4Net.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="xunit" Version="2.4.1" />

--- a/SumoLogic.Logging.Log4Net.Tests/SumoLogic.Logging.Log4Net.Tests.csproj
+++ b/SumoLogic.Logging.Log4Net.Tests/SumoLogic.Logging.Log4Net.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="xunit" Version="2.4.1" />

--- a/SumoLogic.Logging.Log4Net/SumoLogic.Logging.Log4Net.csproj
+++ b/SumoLogic.Logging.Log4Net/SumoLogic.Logging.Log4Net.csproj
@@ -4,7 +4,7 @@
         <Description>Log4Net appender which sends logs to the Sumo Logic machine data analytics platform.</Description>
         <Authors>Sumo Logic</Authors>
         <Copyright>Copyright © 2018 Sumo Logic Inc. - All Rights Reserved</Copyright>
-        <TargetFrameworks>net45;netstandard2.0</TargetFrameworks>
+        <TargetFrameworks>net45;net48;netstandard2.0</TargetFrameworks>
         <SignAssembly Condition="'$(Configuration)' == 'Release' ">true</SignAssembly>
         <AssemblyOriginatorKeyFile>..\SumoLogic.Logging.snk</AssemblyOriginatorKeyFile>
         <PackageProjectUrl>https://github.com/SumoLogic/sumologic-net-appenders</PackageProjectUrl>

--- a/SumoLogic.Logging.Log4Net/SumoLogic.Logging.Log4Net.csproj
+++ b/SumoLogic.Logging.Log4Net/SumoLogic.Logging.Log4Net.csproj
@@ -4,10 +4,9 @@
         <Description>Log4Net appender which sends logs to the Sumo Logic machine data analytics platform.</Description>
         <Authors>Sumo Logic</Authors>
         <Copyright>Copyright © 2018 Sumo Logic Inc. - All Rights Reserved</Copyright>
-        <TargetFrameworks>net45;netstandard1.3</TargetFrameworks>
+        <TargetFrameworks>net45;netstandard2.0</TargetFrameworks>
         <SignAssembly Condition="'$(Configuration)' == 'Release' ">true</SignAssembly>
         <AssemblyOriginatorKeyFile>..\SumoLogic.Logging.snk</AssemblyOriginatorKeyFile>
-        <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.3' ">1.6.1</NetStandardImplicitPackageVersion>
         <PackageProjectUrl>https://github.com/SumoLogic/sumologic-net-appenders</PackageProjectUrl>
         <PackageIconUrl>https://raw.githubusercontent.com/SumoLogic/sumologic-net-appenders/master/icon.png</PackageIconUrl>
         <RepositoryUrl>https://github.com/SumoLogic/sumologic-net-appenders</RepositoryUrl>

--- a/SumoLogic.Logging.NLog.Example/SumoLogic.Logging.NLog.Example.csproj
+++ b/SumoLogic.Logging.NLog.Example/SumoLogic.Logging.NLog.Example.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
     </PropertyGroup>
     <ItemGroup>
         <CodeAnalysisDictionary Include="..\CustomDictionary.xml">

--- a/SumoLogic.Logging.NLog.Example/SumoLogic.Logging.NLog.Example.csproj
+++ b/SumoLogic.Logging.NLog.Example/SumoLogic.Logging.NLog.Example.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
     </PropertyGroup>
     <ItemGroup>
         <CodeAnalysisDictionary Include="..\CustomDictionary.xml">

--- a/SumoLogic.Logging.NLog.Example/SumoLogic.Logging.NLog.Example.csproj
+++ b/SumoLogic.Logging.NLog.Example/SumoLogic.Logging.NLog.Example.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp2.1</TargetFramework>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
     </PropertyGroup>
     <ItemGroup>
         <CodeAnalysisDictionary Include="..\CustomDictionary.xml">

--- a/SumoLogic.Logging.NLog.Tests/SumoLogic.Logging.NLog.Tests.csproj
+++ b/SumoLogic.Logging.NLog.Tests/SumoLogic.Logging.NLog.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>netcoreapp2.1</TargetFramework>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="xunit" Version="2.4.1" />

--- a/SumoLogic.Logging.NLog.Tests/SumoLogic.Logging.NLog.Tests.csproj
+++ b/SumoLogic.Logging.NLog.Tests/SumoLogic.Logging.NLog.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="xunit" Version="2.4.1" />

--- a/SumoLogic.Logging.NLog.Tests/SumoLogic.Logging.NLog.Tests.csproj
+++ b/SumoLogic.Logging.NLog.Tests/SumoLogic.Logging.NLog.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="xunit" Version="2.4.1" />

--- a/SumoLogic.Logging.NLog/SumoLogic.Logging.NLog.csproj
+++ b/SumoLogic.Logging.NLog/SumoLogic.Logging.NLog.csproj
@@ -4,10 +4,9 @@
         <Description>NLog appender which sends logs to the Sumo Logic machine data platform.</Description>
         <Authors>Sumo Logic</Authors>
         <Copyright>Copyright © 2018 Sumo Logic Inc. - All Rights Reserved</Copyright>
-        <TargetFrameworks>net45;netstandard1.3;netstandard2.0</TargetFrameworks>
+        <TargetFrameworks>net45;netstandard2.0</TargetFrameworks>
         <SignAssembly Condition="'$(Configuration)' == 'Release' ">true</SignAssembly>
         <AssemblyOriginatorKeyFile>..\SumoLogic.Logging.snk</AssemblyOriginatorKeyFile>
-        <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.3' ">1.6.1</NetStandardImplicitPackageVersion>
         <PackageProjectUrl>https://github.com/SumoLogic/sumologic-net-appenders</PackageProjectUrl>
         <PackageIconUrl>https://raw.githubusercontent.com/SumoLogic/sumologic-net-appenders/master/icon.png</PackageIconUrl>
         <RepositoryUrl>https://github.com/SumoLogic/sumologic-net-appenders</RepositoryUrl>

--- a/SumoLogic.Logging.NLog/SumoLogic.Logging.NLog.csproj
+++ b/SumoLogic.Logging.NLog/SumoLogic.Logging.NLog.csproj
@@ -4,7 +4,7 @@
         <Description>NLog appender which sends logs to the Sumo Logic machine data platform.</Description>
         <Authors>Sumo Logic</Authors>
         <Copyright>Copyright © 2018 Sumo Logic Inc. - All Rights Reserved</Copyright>
-        <TargetFrameworks>net45;netstandard2.0</TargetFrameworks>
+        <TargetFrameworks>net45;net48;netstandard2.0</TargetFrameworks>
         <SignAssembly Condition="'$(Configuration)' == 'Release' ">true</SignAssembly>
         <AssemblyOriginatorKeyFile>..\SumoLogic.Logging.snk</AssemblyOriginatorKeyFile>
         <PackageProjectUrl>https://github.com/SumoLogic/sumologic-net-appenders</PackageProjectUrl>

--- a/SumoLogic.Logging.Serilog.Example/SumoLogic.Logging.Serilog.Example.csproj
+++ b/SumoLogic.Logging.Serilog.Example/SumoLogic.Logging.Serilog.Example.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
     </PropertyGroup>
     <ItemGroup>
         <CodeAnalysisDictionary Include="..\CustomDictionary.xml">

--- a/SumoLogic.Logging.Serilog.Example/SumoLogic.Logging.Serilog.Example.csproj
+++ b/SumoLogic.Logging.Serilog.Example/SumoLogic.Logging.Serilog.Example.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
     </PropertyGroup>
     <ItemGroup>
         <CodeAnalysisDictionary Include="..\CustomDictionary.xml">

--- a/SumoLogic.Logging.Serilog.Example/SumoLogic.Logging.Serilog.Example.csproj
+++ b/SumoLogic.Logging.Serilog.Example/SumoLogic.Logging.Serilog.Example.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp2.1</TargetFramework>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
     </PropertyGroup>
     <ItemGroup>
         <CodeAnalysisDictionary Include="..\CustomDictionary.xml">

--- a/SumoLogic.Logging.Serilog.Tests/SumoLogic.Logging.Serilog.Tests.csproj
+++ b/SumoLogic.Logging.Serilog.Tests/SumoLogic.Logging.Serilog.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>netcoreapp2.1</TargetFramework>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="xunit" Version="2.4.1" />

--- a/SumoLogic.Logging.Serilog.Tests/SumoLogic.Logging.Serilog.Tests.csproj
+++ b/SumoLogic.Logging.Serilog.Tests/SumoLogic.Logging.Serilog.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="xunit" Version="2.4.1" />

--- a/SumoLogic.Logging.Serilog.Tests/SumoLogic.Logging.Serilog.Tests.csproj
+++ b/SumoLogic.Logging.Serilog.Tests/SumoLogic.Logging.Serilog.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="xunit" Version="2.4.1" />

--- a/SumoLogic.Logging.Serilog/SumoLogic.Logging.Serilog.csproj
+++ b/SumoLogic.Logging.Serilog/SumoLogic.Logging.Serilog.csproj
@@ -4,10 +4,9 @@
         <Description>Serilog sink which sends logs to the Sumo Logic machine data analytics platform.</Description>
         <Authors>Sumo Logic</Authors>
         <Copyright>Copyright © 2018 Sumo Logic Inc. - All Rights Reserved</Copyright>
-        <TargetFrameworks>net45;netstandard1.3;;netstandard2.0</TargetFrameworks>
+        <TargetFrameworks>net45;netstandard2.0</TargetFrameworks>
         <SignAssembly Condition="'$(Configuration)' == 'Release' ">true</SignAssembly>
         <AssemblyOriginatorKeyFile>..\SumoLogic.Logging.snk</AssemblyOriginatorKeyFile>
-        <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.3' ">1.6.1</NetStandardImplicitPackageVersion>
         <PackageProjectUrl>https://github.com/SumoLogic/sumologic-net-appenders</PackageProjectUrl>
         <PackageIconUrl>https://raw.githubusercontent.com/SumoLogic/sumologic-net-appenders/master/icon.png</PackageIconUrl>
         <RepositoryUrl>https://github.com/SumoLogic/sumologic-net-appenders</RepositoryUrl>
@@ -25,10 +24,7 @@
         </CodeAnalysisDictionary>
         <ProjectReference Include="..\SumoLogic.Logging.Common\SumoLogic.Logging.Common.csproj" />
     </ItemGroup>
-	<ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+	<ItemGroup>
             <PackageReference Include="Serilog" Version="[2.0,)" />
-	</ItemGroup>
-	<ItemGroup Condition=" '$(TargetFramework)' == 'net45' Or  '$(TargetFramework)' == 'netstandard1.3'">
-	    <PackageReference Include="Serilog" Version="[2.0,3.0)" />
 	</ItemGroup>
 </Project>

--- a/SumoLogic.Logging.Serilog/SumoLogic.Logging.Serilog.csproj
+++ b/SumoLogic.Logging.Serilog/SumoLogic.Logging.Serilog.csproj
@@ -4,7 +4,7 @@
         <Description>Serilog sink which sends logs to the Sumo Logic machine data analytics platform.</Description>
         <Authors>Sumo Logic</Authors>
         <Copyright>Copyright © 2018 Sumo Logic Inc. - All Rights Reserved</Copyright>
-        <TargetFrameworks>net45;netstandard2.0</TargetFrameworks>
+        <TargetFrameworks>net45;net48;netstandard2.0</TargetFrameworks>
         <SignAssembly Condition="'$(Configuration)' == 'Release' ">true</SignAssembly>
         <AssemblyOriginatorKeyFile>..\SumoLogic.Logging.snk</AssemblyOriginatorKeyFile>
         <PackageProjectUrl>https://github.com/SumoLogic/sumologic-net-appenders</PackageProjectUrl>
@@ -24,7 +24,10 @@
         </CodeAnalysisDictionary>
         <ProjectReference Include="..\SumoLogic.Logging.Common\SumoLogic.Logging.Common.csproj" />
     </ItemGroup>
-	<ItemGroup>
+	<ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' Or '$(TargetFramework)' == 'net48' ">
             <PackageReference Include="Serilog" Version="[2.0,)" />
+	</ItemGroup>
+	<ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
+	    <PackageReference Include="Serilog" Version="[2.0,3.0)" />
 	</ItemGroup>
 </Project>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,10 @@
-image: Visual Studio 2017
+image: Visual Studio 2019
 version: 0.0.0.{build}
+install:
+- ps: |
+    dotnet --version
+    dotnet --list-sdks
+    dotnet --list-runtimes
 build_script:
 - ps: .\ci\build-solution.ps1
 test_script:


### PR DESCRIPTION
Summary of changes

• Fixed Serilog 4.x compatibility - Updated version constraints to support Serilog 2.x, 3.x, and 4.x
• Added .NET Framework 4.8 support - All logging libraries now target net45, net48, and netstandard2.0
• Upgraded to .NET Core 3.1 - All test and example projects modernized from 2.1
• Removed deprecated targets - Eliminated .NET Standard 1.3 to resolve NETSDK1215 warnings
• Fixed package compatibility - Removed Microsoft.AspNetCore.All and updated ASP.NET Core APIs
• Conditional Serilog versioning - net45 uses [2.0,3.0), modern frameworks use [2.0,)Upgrade to  .NET Core 3.1